### PR TITLE
Make symbol case insensitive

### DIFF
--- a/src/dry_bison.y
+++ b/src/dry_bison.y
@@ -1,5 +1,9 @@
 %{
 #include <stdio.h>
+#include <ctype.h>
+#include <wctype.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "ast_bison_helpers.h"
 #include "vinumc.h"
@@ -96,6 +100,24 @@ args:
 
 symbol: WORD {
 	VEC_AT(&ctx.ast.nodes, $1).type = SYMBOL;
+
+	// making so our symbols are case insensitive by making the whole string lowercase
+	char *text = VEC_AT(&ctx.ast.nodes, $1).text;
+	size_t len = strlen(text);
+
+	// we need to convert from multi-byte to wide-character string
+	wchar_t *wtext = (wchar_t*)malloc(len * sizeof(wchar_t));
+	// TODO: handle the function return value
+	mbstowcs(wtext, text, len);
+	
+	for(int i = 0; wtext[i]; i++) {
+		wtext[i] = towlower(wtext[i]);
+	}
+	// converting back to multi-byte
+	// TODO: handle the function return value
+	wcstombs(text, wtext, len);
+	free(wtext);
+
 	$$ = $1;
       }
       | block {

--- a/src/vinumc.c
+++ b/src/vinumc.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stdio.h>
+#include <locale.h>
 
 #include "vinumc.h"
 
@@ -26,6 +27,8 @@ void yyerror(char *s, ...) {
 }
 
 int main() {
+	setlocale(LC_ALL, "");
+
 	ctx = ctx_new();
 	yyparse();
 	ast_print(&ctx.ast);


### PR DESCRIPTION
In the language description we say that symbols are case-insensitive, so this converts every symbol text to lowercase.
This is done by iterating through a SYMBOL node's text and using the C 'tolower' function.