### PR TITLE
vinumc: Add instructions on how to build the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,40 @@
 
 Vinum is document preparation system.
 
-This sofware is in pre-alpha stage.
+This software is in pre-alpha stage.
+
+# vinumc
+
+The Vinum compiler, it turns the `.vin` files into your desired output document
+
+## How to build it
+
+### Dependencies
+
+- C compiler
+- GNU Autotools
+- Bison
+- Flex
+
+This project uses the GNU Autotools for its build system.
+
+This is how you use it.
+
+One the project root, use `autoreconf` to generate the `./configure` script.
+
+```console
+autoreconf -i
+```
+
+Run the `./configure` script for generating the Makefile.
+
+```console
+./configure
+```
+
+And finally, run `make` to build the compiler. For subsequent builds you only
+need to run this last command.
+
+```console
+make
+```


### PR DESCRIPTION
It's good to have instruction for new developers and users on how to build the project. This adds that

Fixes: #18

---

About this PR that I think needs some discussion:

These instructions not only builds the `vinumc` compiler but also builds the `vin2dot` utility. How should I add this info on the readme?