### PR TITLE
Add a --output flag to the compiler

### DIFF
--- a/src/vinumc.c
+++ b/src/vinumc.c
@@ -30,8 +30,10 @@ extern FILE *yyin;
 
 int main(int argc, char **argv) {
 	setlocale(LC_ALL, "");
-	if (argc > 1) {
-		yyin = fopen(argv[1], "r");
+
+	for (int i = 1; i < argc ; i++) {
+		char* arg = argv[i];
+		yyin = fopen(arg, "r");
 	}
 
 	ctx = ctx_new();

--- a/src/vinumc.c
+++ b/src/vinumc.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <locale.h>
+#include <strings.h>
 
 #include "vinumc.h"
 
@@ -31,13 +32,18 @@ extern FILE *yyin;
 int main(int argc, char **argv) {
 	setlocale(LC_ALL, "");
 
+	FILE *out = stdout;
 	for (int i = 1; i < argc ; i++) {
 		char* arg = argv[i];
-		yyin = fopen(arg, "r");
+		if (!strcasecmp("--output", arg)) {
+			out = fopen(argv[++i], "w");
+		} else {
+			yyin = fopen(arg, "r");
+		}
 	}
 
 	ctx = ctx_new();
 	yyparse();
 
-	eval(&ctx.eval_ctx, &ctx.ast, stdout);
+	eval(&ctx.eval_ctx, &ctx.ast, out);
 }


### PR DESCRIPTION
Now the user can specify the output file using ```--output FILE_NAME```, an argument not preceded by the flag will be assumed to be the input file. If no output is specified it will use stdout. 

Closes #13.