### PR TITLE
vinumc: improve text handling

### DIFF
--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -67,6 +67,8 @@ const char *token_to_str(enum yytokentype token) {
 		return "FUNCTION";
 	case TEXT:
 		return "TEXT";
+	case LITERAL:
+		return "LITERAL";
 	default:
 		return NULL;
 	}
@@ -85,7 +87,7 @@ static void ast_print_rec(const struct ast *ast, const int id, const int level) 
 		printf("%s", token_to_str(node->type));
 	}
 
-	if (node->type == TEXT || node->type == SYMBOL) {
+	if (node->type == TEXT || node->type == SYMBOL || node->type == LITERAL) {
 		printf("(%s)", node->text);
 	}
 	printf("\n");

--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -67,8 +67,6 @@ const char *token_to_str(enum yytokentype token) {
 		return "FUNCTION";
 	case TEXT:
 		return "TEXT";
-	case WORD:
-		return "WORD";
 	default:
 		return NULL;
 	}
@@ -87,7 +85,7 @@ static void ast_print_rec(const struct ast *ast, const int id, const int level) 
 		printf("%s", token_to_str(node->type));
 	}
 
-	if (node->type == WORD || node->type == SYMBOL) {
+	if (node->type == TEXT || node->type == SYMBOL) {
 		printf("(%s)", node->text);
 	}
 	printf("\n");

--- a/subprojects/vinumc/dry_bison.y
+++ b/subprojects/vinumc/dry_bison.y
@@ -19,7 +19,6 @@ int yylex();
 // TODO: FUNCTION is not used in bison but in eval
 %token FUNCTION
 %token TEXT
-%token WORD
 
 %%
 
@@ -63,7 +62,7 @@ block:
    ;
 
 args:
-	 text {
+	 TEXT {
 		struct ast_node node = ast_node_new_nvl(ARGS);
 
 		ast_node_add_child(&node, $1);
@@ -86,7 +85,7 @@ args:
 
 		$$ = ast_add_node(&ctx.ast, node);
 	 }
-	 | args text {
+	 | args TEXT {
 		struct ast_node *node = &VEC_AT(&ctx.ast.nodes, $1);
 
 		ast_node_add_child(node, $2);
@@ -109,9 +108,7 @@ args:
 	 }
 	 ;
 
-symbol: WORD {
-	VEC_AT(&ctx.ast.nodes, $1).type = SYMBOL;
-
+symbol: SYMBOL {
 	// making so our symbols are case insensitive by making the whole string lowercase
 	char *text = VEC_AT(&ctx.ast.nodes, $1).text;
 	size_t len = strlen(text);
@@ -120,7 +117,7 @@ symbol: WORD {
 	wchar_t *wtext = (wchar_t*)malloc(len * sizeof(wchar_t));
 	// TODO: handle the function return value
 	mbstowcs(wtext, text, len);
-	
+
 	for(size_t i = 0; i < len; i++) {
 		wtext[i] = towlower(wtext[i]);
 	}
@@ -139,26 +136,4 @@ symbol: WORD {
 	$$ = ast_add_node(&ctx.ast, node);
       }
       ;
-
-text:
-     word_text {
-	struct ast_node node = ast_node_new_nvl(TEXT);
-
-	ast_node_add_child(&node, $1);
-
-	$$ = ast_add_node(&ctx.ast, node);
-    }
-    | text word_text {
-	struct ast_node *node = &VEC_AT(&ctx.ast.nodes, $1);
-
-	ast_node_add_child(node, $2);
-
-	$$ = $1;
-    }
-    ;
-
-word_text: WORD { $$ = $1;}
-	 | ':'{ $$ = $1;}
-	 ;
-
 %%

--- a/subprojects/vinumc/dry_bison.y
+++ b/subprojects/vinumc/dry_bison.y
@@ -19,6 +19,7 @@ int yylex();
 // TODO: FUNCTION is not used in bison but in eval
 %token FUNCTION
 %token TEXT
+%token LITERAL
 
 %%
 
@@ -62,51 +63,27 @@ block:
    ;
 
 args:
-	 TEXT {
+	args_child {
 		struct ast_node node = ast_node_new_nvl(ARGS);
-
-		ast_node_add_child(&node, $1);
-
-		size_t arg_node_id = ast_add_node(&ctx.ast, node);
-
-		$$ = arg_node_id;
-	 }
-	 | block {
-		struct ast_node node = ast_node_new_nvl(ARGS);
-
 		ast_node_add_child(&node, $1);
 
 		$$ = ast_add_node(&ctx.ast, node);
-	 }
-	 | ARG_REF_ALL_ARGS {
-		struct ast_node node = ast_node_new_nvl(ARGS);
-
-		ast_node_add_child(&node, $1);
-
-		$$ = ast_add_node(&ctx.ast, node);
-	 }
-	 | args TEXT {
+	}
+	| args args_child {
 		struct ast_node *node = &VEC_AT(&ctx.ast.nodes, $1);
 
 		ast_node_add_child(node, $2);
 
 		$$ = $1;
-	 }
-	 | args block {
-		struct ast_node *node = &VEC_AT(&ctx.ast.nodes, $1);
+	}
+	;
 
-		ast_node_add_child(node, $2);
-
-		$$ = $1;
-	 }
-	 | args ARG_REF_ALL_ARGS {
-		struct ast_node *node = &VEC_AT(&ctx.ast.nodes, $1);
-
-		ast_node_add_child(node, $2);
-
-		$$ = $1;
-	 }
-	 ;
+args_child:
+	TEXT { $$ = $1; }
+	| block { $$ = $1; }
+	| ARG_REF_ALL_ARGS { $$ = $1; }
+	| LITERAL { $$ = $1; }
+	;
 
 symbol: SYMBOL {
 	// making so our symbols are case insensitive by making the whole string lowercase

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -1,4 +1,9 @@
-%option noyywrap nodefault yylineno
+%option noyywrap nodefault yylineno noyy_top_state
+%option stack
+
+%x DEFINE_CALL_NAME
+%x HAS_CALL_NAME
+%x CONTENT
 
 %{
 #include <string.h>
@@ -14,30 +19,76 @@
  */
 #define YY_NO_INPUT
 #define YY_NO_UNPUT
+
+static void replace_state(int new_state);
+static int yield_text_node(void);
 %}
 
+BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 %%
 
-"[" |
-"]" |
-":" { return *yytext; }
 
-[ \t\n\r]+ { }
+<INITIAL>[ \t\r\n]+ ;
+<INITIAL>[^\[\] \t\r\n]+ {
+	struct ast_node node = ast_node_new(TEXT, strdup(yytext));
+	yylval = ast_add_node(&ctx.ast, node);
 
-"$*" {
+	return TEXT;
+}
+
+<INITIAL,CONTENT>"[" { yy_push_state(DEFINE_CALL_NAME); return *yytext; }
+<INITIAL>"]" { return *yytext; }
+<CONTENT>"]" { yy_pop_state(); return *yytext; }
+
+<DEFINE_CALL_NAME>"[" {
+	replace_state(HAS_CALL_NAME);
+	yy_push_state(DEFINE_CALL_NAME);
+	return *yytext;
+}
+<DEFINE_CALL_NAME,HAS_CALL_NAME>"]" { yy_pop_state(); return *yytext; }
+<DEFINE_CALL_NAME,HAS_CALL_NAME>[ \t]*: { replace_state(CONTENT); return ':'; }
+<DEFINE_CALL_NAME>[ \t\r\n]+ ;
+<DEFINE_CALL_NAME>[^\[\]: \t\r\n]+ {
+	struct ast_node node = ast_node_new(SYMBOL, strdup(yytext));
+	yylval = ast_add_node(&ctx.ast, node);
+
+	replace_state(HAS_CALL_NAME);
+
+	return SYMBOL;
+}
+<HAS_CALL_NAME>[ \t\r\n] { replace_state(CONTENT); }
+<HAS_CALL_NAME>. { replace_state(CONTENT); yyless(0); }
+
+<CONTENT>"$*" {
 	struct ast_node node = ast_node_new_nvl(ARG_REF_ALL_ARGS);
 	yylval = ast_add_node(&ctx.ast, node);
 
 	return ARG_REF_ALL_ARGS;
 }
 
-([^\[\]: \t\r\n])+ {
-	struct ast_node node = ast_node_new(WORD, strdup(yytext));
-	yylval = ast_add_node(&ctx.ast, node);
-
-	return WORD;
+<CONTENT>([^\[\]])/({BEFORE_TEXT_END}) {
+	return yield_text_node();
+}
+<CONTENT>([^\[\]])/(.|\n) {
+	yymore();
+}
+<CONTENT>([^\[\]]) {
+	// the next token is eof, so we yield the
+	// contents buffered so far
+	return yield_text_node();
 }
 
-. { yyerror("[ERROR]  \"%c\" not covered", *yytext); }
+<*>. { yyerror("[ERROR]  \"%c\" not covered", *yytext); }
 
 %%
+
+static void replace_state(int new_state) {
+	yy_pop_state();
+	yy_push_state(new_state);
+}
+
+static int yield_text_node(void) {
+	struct ast_node node = ast_node_new(TEXT, strdup(yytext));
+	yylval = ast_add_node(&ctx.ast, node);
+	return TEXT;
+}

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -11,6 +11,7 @@
 #include "dry_bison.h"
 
 #include "vinumc.h"
+#include "str.h"
 
 /*
  * Disables input() and unput() function definitions from the generated .c
@@ -22,6 +23,11 @@
 
 static void replace_state(int new_state);
 static int yield_text_node(void);
+
+// used to handle character escaping inside the regular text blocks
+// preventing having two consecutive TEXT nodes
+// that could be just one node
+static struct str text_buffer = {};
 %}
 
 BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
@@ -66,15 +72,31 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 	return ARG_REF_ALL_ARGS;
 }
 
+<CONTENT>\\(.|\n)/({BEFORE_TEXT_END}) {
+	VEC_PUT(&text_buffer, yytext[1]);
+	return yield_text_node();
+}
+<CONTENT>\\(.|\n)/(.|\n) {
+	VEC_PUT(&text_buffer, yytext[1]);
+}
+<CONTENT>\\(.|\n) {
+	// the next token is eof, so we yield the
+	// contents buffered so far
+	VEC_PUT(&text_buffer, yytext[1]);
+	return yield_text_node();
+}
+
 <CONTENT>([^\[\]])/({BEFORE_TEXT_END}) {
+	VEC_PUT(&text_buffer, *yytext);
 	return yield_text_node();
 }
 <CONTENT>([^\[\]])/(.|\n) {
-	yymore();
+	VEC_PUT(&text_buffer, *yytext);
 }
 <CONTENT>([^\[\]]) {
 	// the next token is eof, so we yield the
 	// contents buffered so far
+	VEC_PUT(&text_buffer, *yytext);
 	return yield_text_node();
 }
 
@@ -88,7 +110,10 @@ static void replace_state(int new_state) {
 }
 
 static int yield_text_node(void) {
-	struct ast_node node = ast_node_new(TEXT, strdup(yytext));
+	VEC_PUT(&text_buffer, '\0');
+	struct ast_node node = ast_node_new(TEXT, text_buffer.base);
+	// transfers the string to the ast node
+	text_buffer = (struct str){};
 	yylval = ast_add_node(&ctx.ast, node);
 	return TEXT;
 }

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -4,6 +4,7 @@
 %x DEFINE_CALL_NAME
 %x HAS_CALL_NAME
 %x CONTENT
+%x IN_LITERAL
 
 %{
 #include <string.h>
@@ -71,6 +72,27 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 
 	return ARG_REF_ALL_ARGS;
 }
+
+<CONTENT>"{#" { yy_push_state(IN_LITERAL); }
+<IN_LITERAL>"#}" {
+	struct ast_node node = ast_node_new(LITERAL, strndup(yytext, yyleng - 2));
+	yylval = ast_add_node(&ctx.ast, node);
+
+	yy_pop_state();
+	return LITERAL;
+}
+<IN_LITERAL>(.|\n)/(.|\n) {
+	yymore();
+}
+<IN_LITERAL>(.|\n) {
+	// the next token is eof, so we yield the
+	// contents buffered so far
+	struct ast_node node = ast_node_new(LITERAL, strndup(yytext, yyleng));
+	yylval = ast_add_node(&ctx.ast, node);
+	yy_pop_state();
+	return LITERAL;
+}
+
 
 <CONTENT>\\(.|\n)/({BEFORE_TEXT_END}) {
 	VEC_PUT(&text_buffer, yytext[1]);

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -11,6 +11,12 @@
 #include "v_lib.h"
 #include "vec.h"
 
+enum do_calls_flag {
+	REDUCE_BLANKS = 1 << 0,
+	FIRST_CHILD = 1 << 1,
+	LAST_CHILD = 1 << 2,
+};
+
 struct eval_ctx eval_ctx_new() {
 	struct eval_ctx ret = {};
 
@@ -205,14 +211,22 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls) {
 
 #define DO_CALLS_FUNC_SIGNATURE(func_name)                                                         \
 	static void func_name(struct eval_ctx *ctx, const struct ast *ast, struct str *out,        \
-			      size_t ast_node_id)
+			      size_t ast_node_id, int flags)
 
 DO_CALLS_FUNC_SIGNATURE(do_calls);
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_program) {
 	const struct ast_node *ast_node = &VEC_AT(&ast->nodes, ast_node_id);
 	for (size_t i = 0; i < ast_node->childs.len; i++) {
-		do_calls(ctx, ast, out, VEC_AT(&ast_node->childs, i));
+		size_t child_id = VEC_AT(&ast_node->childs, i);
+		int sub_flags = flags & ~(FIRST_CHILD | LAST_CHILD);
+		if (i == 0) {
+			sub_flags |= FIRST_CHILD;
+		}
+		if (i == ast_node->childs.len - 1) {
+			sub_flags |= LAST_CHILD;
+		}
+		do_calls(ctx, ast, out, child_id, sub_flags);
 	}
 }
 
@@ -224,17 +238,14 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 	}
 
 	const struct ast_node *symbol_node = &VEC_AT(&ast->nodes, VEC_AT(&ast_node->childs, 0));
-	const struct ast_node *args_node = &VEC_AT(&ast->nodes, VEC_AT(&ast_node->childs, 1));
+	size_t args_id = VEC_AT(&ast_node->childs, 1);
 
 	if (symbol_node->type == FUNCTION) {
 		// writes the returns of the arguments calls to a temporary buffer,
 		// so any nested call will be resolved normally
 		struct str tmp_out = {};
 		VEC_PUT(&tmp_out, '\0');
-
-		for (size_t i = 0; i < args_node->childs.len; i++) {
-			do_calls(ctx, ast, &tmp_out, VEC_AT(&args_node->childs, i));
-		}
+		do_calls(ctx, ast, &tmp_out, args_id, flags);
 
 		// find the extern function on the scope
 		struct scope *curr_scope = &VEC_AT(&ctx->scopes, 0);
@@ -246,16 +257,19 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 		struct return_value call_return = symbol_info->as.func(&cctx);
 
 		// put the extern function call return on the out str
-		put_str(out, call_return.ptr);
+
+		if ((flags & REDUCE_BLANKS) != 0) {
+			put_blank_reduced_str(out, call_return.ptr, true, true);
+		} else {
+			put_str(out, call_return.ptr);
+		}
 
 		if (call_return.free) {
 			free(call_return.ptr);
 		}
 		VEC_FREE(&tmp_out);
 	} else {
-		for (size_t i = 0; i < args_node->childs.len; i++) {
-			do_calls(ctx, ast, out, VEC_AT(&args_node->childs, i));
-		}
+		do_calls(ctx, ast, out, args_id, flags);
 	}
 }
 
@@ -263,18 +277,13 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_text) {
 	UNUSED(ctx);
 	const struct ast_node *ast_node = &VEC_AT(&ast->nodes, ast_node_id);
 
-	for (size_t i = 0; i < ast_node->childs.len; i++) {
-		const struct ast_node *child = &VEC_AT(&ast->nodes, VEC_AT(&ast_node->childs, i));
-		if (child->type != WORD) {
-			fprintf(stderr, "ERROR: TEXT node must hold only WORDS\n");
-			return;
-		}
-
-		put_str(out, child->text);
-		if (i != ast_node->childs.len - 1)
-			put_str(out, " ");
+	if ((flags & REDUCE_BLANKS) != 0) {
+		bool trim_left = (flags & FIRST_CHILD) != 0;
+		bool trim_right = (flags & LAST_CHILD) != 0;
+		put_blank_reduced_str(out, ast_node->text, trim_left, trim_right);
+	} else {
+		put_str(out, ast_node->text);
 	}
-	put_str(out, "\n");
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls) {
@@ -283,13 +292,13 @@ DO_CALLS_FUNC_SIGNATURE(do_calls) {
 	switch (ast_node->type) {
 	case PROGRAM:
 	case ARGS:
-		do_calls_program(ctx, ast, out, ast_node_id);
+		do_calls_program(ctx, ast, out, ast_node_id, flags);
 		break;
 	case CALL:
-		do_calls_call(ctx, ast, out, ast_node_id);
+		do_calls_call(ctx, ast, out, ast_node_id, flags);
 		break;
 	case TEXT:
-		do_calls_text(ctx, ast, out, ast_node_id);
+		do_calls_text(ctx, ast, out, ast_node_id, flags);
 		break;
 	default:
 		break;
@@ -349,7 +358,7 @@ void eval(struct eval_ctx *ctx, struct ast *ast, FILE *out, struct str_vec *libr
 	struct str str_out = {};
 	VEC_PUT(&str_out, '\0');
 
-	do_calls(ctx, ast, &str_out, 0);
+	do_calls(ctx, ast, &str_out, 0, REDUCE_BLANKS);
 	fprintf(out, "%s", str_out.base);
 	unload_libs(loaded_libs);
 }

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -298,6 +298,7 @@ DO_CALLS_FUNC_SIGNATURE(do_calls) {
 		do_calls_call(ctx, ast, out, ast_node_id, flags);
 		break;
 	case TEXT:
+	case LITERAL:
 		do_calls_text(ctx, ast, out, ast_node_id, flags);
 		break;
 	default:

--- a/subprojects/vinumc/str.c
+++ b/subprojects/vinumc/str.c
@@ -1,5 +1,10 @@
-#include "str.h"
 #include <string.h>
+
+#include "str.h"
+
+static bool is_blank_char(char c) {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
 
 void put_str(struct str *to, char *from) {
 	if ((to)->len > 0) {
@@ -7,5 +12,48 @@ void put_str(struct str *to, char *from) {
 	}
 	size_t _len = strlen(from);
 	VEC_PUT_MANY(to, from, _len);
+	VEC_PUT(to, '\0');
+}
+
+// Puts the contents of `from` into `to`, performing blank reduction,
+// that is, collapsing consecutive blank characters into a single space.
+//
+// If `trim_left` is true, leading blanks are removed.
+// If `trim_right` is true, trailing blanks are removed.
+void put_blank_reduced_str(struct str *to, char *from, bool trim_left, bool trim_right) {
+	if (to->len > 0) {
+		VEC_POP(to);
+	}
+
+	size_t start = 0;
+	size_t end = strlen(from);
+	if (trim_left) {
+		while (start < end && is_blank_char(from[start])) {
+			start++;
+		}
+	}
+	if (trim_right) {
+		while (end > start && is_blank_char(from[end - 1])) {
+			end--;
+		}
+	}
+
+	bool is_previous_blank = to->len == 0 || is_blank_char(VEC_AT(to, to->len - 1));
+
+	VEC_RESERVE(to, (end - start + 1));
+	for (size_t i = start; i < end; i++) {
+		char c = from[i];
+
+		if (!is_blank_char(c)) {
+			VEC_PUT(to, c);
+			is_previous_blank = false;
+			continue;
+		}
+		if (is_previous_blank) {
+			continue;
+		}
+		is_previous_blank = true;
+		VEC_PUT(to, ' ');
+	}
 	VEC_PUT(to, '\0');
 }

--- a/subprojects/vinumc/str.h
+++ b/subprojects/vinumc/str.h
@@ -1,10 +1,14 @@
 #ifndef __STR_H__
 #define __STR_H__
 
+#include <stdbool.h>
+
 #include "vec.h"
 
 struct str VEC_DEF(char);
 
 void put_str(struct str *to, char *from);
+
+void put_blank_reduced_str(struct str *to, char *from, bool trim_left, bool trim_right);
 
 #endif // __STR_H__

--- a/subprojects/vinumc/tests/library_test.c
+++ b/subprojects/vinumc/tests/library_test.c
@@ -6,7 +6,7 @@ void test_call(struct vunit_test_ctx *ctx) {
 	vunit_run_vinumc_ok(ctx, "[return_arg test]\n", &out, "--with",
 			    "subprojects/vinumc/tests/libtestlib.so", NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "test\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "test");
 }
 
 void test_nested_call(struct vunit_test_ctx *ctx) {
@@ -17,7 +17,7 @@ void test_nested_call(struct vunit_test_ctx *ctx) {
 			    "[a]\n",
 			    &out, "--with", "subprojects/vinumc/tests/libtestlib.so", NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "This is a\nTest!\n!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "This is a Test!!");
 }
 
 void test_empty_nested_call(struct vunit_test_ctx *ctx) {

--- a/subprojects/vinumc/tests/meson.build
+++ b/subprojects/vinumc/tests/meson.build
@@ -5,12 +5,13 @@ tests = [
   'library_test.c',
   'output_flag_test.c',
   'simple_test.c',
+  'text_handling_test.c',
 ]
 
 vunit_dep = dependency('vunit', fallback : ['vunit', 'vunit_dep'])
 
 foreach t : tests
-  basename = fs.stem(t) 
+  basename = fs.stem(t)
 
   test_exe = executable(
     basename,

--- a/subprojects/vinumc/tests/output_flag_test.c
+++ b/subprojects/vinumc/tests/output_flag_test.c
@@ -10,7 +10,7 @@ void test_output_flag(struct vunit_test_ctx *ctx) {
 			    &out, "-o", "out.txt", NULL);
 
 	char *out_file_str = vunit_file_to_str(ctx, "out.txt");
-	VUNIT_ASSERT_STREQ(ctx, out_file_str, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out_file_str, "Hello World!");
 	VUNIT_ASSERT_STREQ(ctx, out, "");
 
 	free(out_file_str);
@@ -24,7 +24,7 @@ void test_output_flag(struct vunit_test_ctx *ctx) {
 	out_file_str = vunit_file_to_str(ctx, "out.txt");
 	VUNIT_ASSERT_STREQ(ctx, out, "");
 
-	VUNIT_ASSERT_STREQ(ctx, out_file_str, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out_file_str, "Hello World!");
 }
 
 struct vunit_test tests[] = {

--- a/subprojects/vinumc/tests/simple_test.c
+++ b/subprojects/vinumc/tests/simple_test.c
@@ -8,7 +8,7 @@ void test_basic(struct vunit_test_ctx *ctx) {
 			    "[a]\n",
 			    &out, NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
 void test_define_later(struct vunit_test_ctx *ctx) {
@@ -19,7 +19,7 @@ void test_define_later(struct vunit_test_ctx *ctx) {
 			    "[a: Hello World!]\n",
 			    &out, NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
 void test_function_text_args(struct vunit_test_ctx *ctx) {
@@ -30,7 +30,7 @@ void test_function_text_args(struct vunit_test_ctx *ctx) {
 			    "[a Hello World!]\n",
 			    &out, NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
 void test_function_call_args(struct vunit_test_ctx *ctx) {
@@ -42,7 +42,7 @@ void test_function_call_args(struct vunit_test_ctx *ctx) {
 			    "[b [a]]\n",
 			    &out, NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
 void test_file_input(struct vunit_test_ctx *ctx) {
@@ -55,7 +55,7 @@ void test_file_input(struct vunit_test_ctx *ctx) {
 
 	vunit_run_vinumc_ok(ctx, NULL, &out, "input.vin", NULL);
 
-	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!\n");
+	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
 struct vunit_test tests[] = {

--- a/subprojects/vinumc/tests/text_handling_test.c
+++ b/subprojects/vinumc/tests/text_handling_test.c
@@ -22,9 +22,20 @@ void test_character_escaping(struct vunit_test_ctx *ctx) {
 	VUNIT_ASSERT_STREQ(ctx, out, "[ hello ] {# world #}!");
 }
 
+void test_literal_delimiter(struct vunit_test_ctx *ctx) {
+	char *out = NULL;
+	vunit_run_vinumc_ok(ctx,
+			    "[a: {# [hello] {# world #}#}]\n"
+			    "[a]\n",
+			    &out, NULL);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "[hello] {# world #}");
+}
+
 struct vunit_test tests[] = {
 	{ .name = "Test blank reduction", .test_func = test_blank_reduction },
 	{ .name = "Test character escaping", .test_func = test_character_escaping },
+	{ .name = "Test literal delimiter", .test_func = test_literal_delimiter },
 	{},
 };
 

--- a/subprojects/vinumc/tests/text_handling_test.c
+++ b/subprojects/vinumc/tests/text_handling_test.c
@@ -11,8 +11,20 @@ void test_blank_reduction(struct vunit_test_ctx *ctx) {
 	VUNIT_ASSERT_STREQ(ctx, out, "Content with spaces!");
 }
 
+void test_character_escaping(struct vunit_test_ctx *ctx) {
+	char *out = NULL;
+
+	vunit_run_vinumc_ok(ctx,
+			    "[a: \\[ hello \\] \\{# world #}!]\n"
+			    "[a]\n",
+			    &out, NULL);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "[ hello ] {# world #}!");
+}
+
 struct vunit_test tests[] = {
 	{ .name = "Test blank reduction", .test_func = test_blank_reduction },
+	{ .name = "Test character escaping", .test_func = test_character_escaping },
 	{},
 };
 

--- a/subprojects/vinumc/tests/text_handling_test.c
+++ b/subprojects/vinumc/tests/text_handling_test.c
@@ -1,0 +1,19 @@
+#include <vunit.h>
+
+void test_blank_reduction(struct vunit_test_ctx *ctx) {
+	char *out = NULL;
+
+	vunit_run_vinumc_ok(ctx,
+			    "[a:    Content   with spaces!    ]\n"
+			    "[a]\n",
+			    &out, NULL);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "Content with spaces!");
+}
+
+struct vunit_test tests[] = {
+	{ .name = "Test blank reduction", .test_func = test_blank_reduction },
+	{},
+};
+
+VUNIT_TEST_SUITE(tests)


### PR DESCRIPTION
Closes #1.
Fixes #38.
Closes #41.
Closes #5.
Fixes #70.

- [x] update grammar to take whitespace into account
- [x] perform blank reduction in eval
- [x] literal delimiter
- [x] character escaping
- [x] write tests for the literal delimiter
- [x] write tests for character escaping