### PR TITLE
vinumc/tests: add test_call_no_args to test suite

### DIFF
--- a/subprojects/vinumc/tests/library_test.c
+++ b/subprojects/vinumc/tests/library_test.c
@@ -40,4 +40,5 @@ void test_call_no_args(struct vunit_test_ctx *ctx) {
 
 VUNIT_TEST_SUITE("suite", { "Test extern library call", test_call },
 		 { "Test extern library call inside call", test_nested_call },
-		 { "Test nested empty library calls", test_empty_nested_call }, {}, )
+		 { "Test nested empty library calls", test_empty_nested_call },
+		 { "Test extern library call with no arguments", test_call_no_args }, {}, )


### PR DESCRIPTION
I forgot to add the new test in #68 to the test suite, this pr fixes that.