### PR TITLE
vinumc/vec.h: VEC_RESERVE and VEC_RESERVE_EXACT

### DIFF
--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -38,7 +38,7 @@ ast_node_id_t ast_copy_node(struct ast *ast, ast_node_id_t node_id) {
 	struct ast_node *node_copy = &VEC_AT(&ast->nodes, node_copy_id);
 
 	struct ast_node_childs_t childs = VEC_AT(&ast->nodes, node_id).childs;
-	VEC_RESERVE(&node_copy->childs, childs.len);
+	VEC_RESERVE_EXACT(&node_copy->childs, childs.len);
 
 	for (size_t i = 0; i < childs.len; i++) {
 		size_t child_copy_id = ast_copy_node(ast, VEC_AT(&childs, i));

--- a/subprojects/vinumc/vec.h
+++ b/subprojects/vinumc/vec.h
@@ -27,10 +27,23 @@
 		(arr)->len++;                                                                      \
 	} while (0)
 
-#define VEC_RESERVE(arr, size)                                                                     \
+#define VEC_RESERVE_EXACT(arr, size)                                                               \
 	do {                                                                                       \
 		(arr)->capacity = (size);                                                          \
 		(arr)->base = realloc((arr)->base, (arr)->capacity * sizeof(*(arr)->base));        \
+	} while (0)
+
+#define VEC_RESERVE(arr, size)                                                                     \
+	do {                                                                                       \
+		size_t needed = (arr)->len + size;                                                 \
+		if (needed <= (arr)->capacity)                                                     \
+			break;                                                                     \
+		/* rounds needed to the nearest power of 2 >= its current value */                 \
+		needed--;                                                                          \
+		for (size_t i = 1; i < sizeof(size_t) * 8; i <<= 1)                                \
+			needed |= needed >> i;                                                     \
+		needed++;                                                                          \
+		VEC_RESERVE_EXACT(arr, needed);                                                    \
 	} while (0)
 
 #define VEC_FREE(vec)                                                                              \


### PR DESCRIPTION
Updates `vec.h`  to have two distinct macros: 
- `VEC_RESERVE_EXACT`, which allocates exactly `size` items (current behavior of `VEC_RESERVE`)
- `VEC_RESERVE`, which allocates `n` items such that $n = 2^p \geq \mathsf{len} + \mathsf{size}$ and $p$ is the smallest integer that satisfies the equation.