### PR TITLE
vunit: Isolate single test run to avoid release mode clobbered warning

### DIFF
--- a/subprojects/vunit/meson.build
+++ b/subprojects/vunit/meson.build
@@ -1,4 +1,4 @@
-project('vunit', 'c')
+project('vunit', 'c', version: '0.0.1')
 
 inc = include_directories('include')
 

--- a/subprojects/vunit/vunit.c
+++ b/subprojects/vunit/vunit.c
@@ -107,6 +107,32 @@ static size_t get_num_tests(const struct vunit_test *tests) {
 	return num;
 }
 
+enum test_return_status {
+	PASSED = 0,
+	FAILED,
+	SKIPPED,
+};
+
+static enum test_return_status run_test(const struct vunit_test *test, struct vunit_test_ctx *ctx) {
+	if (test->skip) {
+		return SKIPPED;
+	}
+
+	int ret = setjmp(ctx->env);
+
+	bool test_failed = false;
+	if (!ret) {
+		test->test_func(ctx);
+	} else {
+		test_failed = true;
+	}
+
+	if (test_failed)
+		return FAILED;
+
+	return PASSED;
+}
+
 int __vunit_main(const struct vunit_test *tests, int argc, char *argv[]) {
 	// TODO: Make use of the command args
 	(void)argc;
@@ -121,27 +147,21 @@ int __vunit_main(const struct vunit_test *tests, int argc, char *argv[]) {
 		const struct vunit_test *test = &tests[i];
 		struct vunit_test_ctx ctx = {};
 
-		if (test->skip) {
+		enum test_return_status status = run_test(test, &ctx);
+
+		switch (status) {
+		case PASSED:
+			printf("ok %zu - %s\n", i + 1, test->name);
+			break;
+		case FAILED:
+			printf("not ok %zu - %s\n", i + 1, test->name);
+			if (ctx.lonjmp_msg != NULL)
+				printf("%s\n", ctx.lonjmp_msg);
+			break;
+		case SKIPPED:
 			printf("ok %zu - %s # SKIP\n", i + 1, test->name);
-			continue;
+			break;
 		}
-
-		int ret = setjmp(ctx.env);
-
-		bool test_failed = false;
-		if (!ret) {
-			test->test_func(&ctx);
-		} else {
-			test_failed = true;
-		}
-
-		if (test_failed)
-			printf("not ");
-
-		printf("ok %zu - %s\n", i + 1, test->name);
-
-		if (test_failed && ctx.lonjmp_msg != NULL)
-			printf("%s\n", ctx.lonjmp_msg);
 	}
 
 	return 0;


### PR DESCRIPTION
When compiling in release mode with gcc the folowing error appears:

```
../subprojects/vunit/vunit.c:In function ‘__vunit_main’:
../subprojects/vunit/vunit.c:96:16: error: variable ‘num’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Werror=clobbered]
   96 |         size_t num = 0;
      |                ^~~

```
This happening because the compiler inlines the function get_num_tests() called in function the uses setjmp (__vunit_main()).

To fix that, isolate the procedure inside the loop that runs a single test and has the setjmp.