### PR TITLE
vinumc/tests: Make test depends on testlib.so

### DIFF
--- a/subprojects/vinumc/tests/meson.build
+++ b/subprojects/vinumc/tests/meson.build
@@ -11,6 +11,18 @@ tests = [
 
 vunit_dep = dependency('vunit', fallback : ['vunit', 'vunit_dep'])
 
+testlib_srcs = [
+  'testlib.c',
+]
+
+testlib = shared_library(
+  'testlib',
+  testlib_srcs,
+  dependencies : extern_library_dep,
+  link_depends: extern_library,
+  install : true,
+)
+
 foreach t : tests
   basename = fs.stem(t)
 
@@ -33,19 +45,10 @@ foreach t : tests
     test_exe,
     env : test_env,
     protocol : 'tap',
-    depends: vinumc,
+    depends: [
+      vinumc,
+      testlib,
+    ],
     kwargs: test_kwargs,
   )
 endforeach
-
-testlib_srcs = [
-  'testlib.c',
-]
-
-testlib = shared_library(
-  'testlib',
-  testlib_srcs,
-  dependencies : extern_library_dep,
-  link_depends: extern_library,
-  install : true,
-)


### PR DESCRIPTION
If you do `meson test` on a clean build directory the library_tests break because testlib.so doesn't build. To solve that, make all tests depend on the library.