### PR TITLE
vinumc: expose eval context to external functions

### DIFF
--- a/docs/library_development.md
+++ b/docs/library_development.md
@@ -27,6 +27,8 @@ You can use this functions to get data from the callee context:
 ```c
 // get all the args text
 struct return_value ctx_get_arg(call_ctx ctx);
+// evalues and returns the text value of a symbol finding it by name
+struct return_value ctx_eval_symbol(call_ctx ctx, const char *name);
 ```
 
 ## 4. Register your functions

--- a/docs/library_development.md
+++ b/docs/library_development.md
@@ -18,7 +18,7 @@ Where return_value is defined as:
 struct return_value {
   char *ptr; // the return string
   bool free; // indicates whether ptr should be freed
-  bool status; // indicates if the function succeed 
+  bool status; // indicates if the function succeed
 };
 ```
 
@@ -26,7 +26,7 @@ struct return_value {
 You can use this functions to get data from the callee context:
 ```c
 // get all the args text
-struct return_value ctx_get_text(call_ctx ctx);
+struct return_value ctx_get_arg(call_ctx ctx);
 ```
 
 ## 4. Register your functions
@@ -48,7 +48,7 @@ Compile your library as a shared object:
 ```sh
 gcc -shared -fPIC -o your_lib.so your_lib.c -I/path/to/extern_library.h -L/path/to/libextern_library.so -lextern_library
 ```
-Where 
+Where
 
 ## 6. Usage
 

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -11,6 +11,7 @@
 #include "eval.h"
 #include "extern_library.h"
 #include "library_loader.h"
+#include "libvinumc.h"
 #include "utils.h"
 #include "v_lib.h"
 
@@ -93,20 +94,20 @@ static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size
 }
 
 #define RESOLVE_FUNC_SIGNATURE(func_name)                                                          \
-	static void func_name(struct eval_ctx *ctx, struct ast *ast, size_t curr_scope_id,         \
-			      size_t ast_node_id)
+	static void func_name(struct compiler_ctx *cctx, size_t curr_scope_id, size_t ast_node_id)
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols);
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols_descent) {
-	for (size_t i = 0; i < ast_get_num_child(ast, ast_node_id); i++) {
-		resolve_symbols(ctx, ast, curr_scope_id, ast_get_nth_child(ast, ast_node_id, i));
+	for (size_t i = 0; i < ast_get_num_child(&cctx->ast, ast_node_id); i++) {
+		resolve_symbols(cctx, curr_scope_id, ast_get_nth_child(&cctx->ast, ast_node_id, i));
 	}
 }
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols_assignment) {
-	struct scope *curr_scope = &VUT_VEC_AT(&ctx->scopes, curr_scope_id);
+	struct scope *curr_scope = &VUT_VEC_AT(&cctx->eval_ctx.scopes, curr_scope_id);
 
+	struct ast *ast = &cctx->ast;
 	struct vut_sv name = ast_get_text(ast, ast_get_nth_child(ast, ast_node_id, 0));
 	struct namespace_entry entry = {
 		.name = name,
@@ -120,31 +121,36 @@ RESOLVE_FUNC_SIGNATURE(resolve_symbols_assignment) {
 }
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols) {
+	struct ast *ast = &cctx->ast;
+	struct eval_ctx *ctx = &cctx->eval_ctx;
 	if (ast_get_type(ast, ast_node_id) == ASSIGNMENT) {
-		resolve_symbols_assignment(ctx, ast, curr_scope_id, ast_node_id);
+		resolve_symbols_assignment(cctx, curr_scope_id, ast_node_id);
 	} else {
 		if (ast_get_type(ast, ast_node_id) == CALL)
 			curr_scope_id = add_scope_child(&ctx->scopes, curr_scope_id, ast_node_id,
 							ctx->allocator);
-		resolve_symbols_descent(ctx, ast, curr_scope_id, ast_node_id);
+		resolve_symbols_descent(cctx, curr_scope_id, ast_node_id);
 	}
 }
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls);
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls_descent) {
+	struct ast *ast = &cctx->ast;
 	for (size_t i = 0; i < ast_get_num_child(ast, ast_node_id); i++) {
-		resolve_calls(ctx, ast, curr_scope_id, ast_get_nth_child(ast, ast_node_id, i));
+		resolve_calls(cctx, curr_scope_id, ast_get_nth_child(ast, ast_node_id, i));
 	}
 }
 
 #define DO_CALLS_FUNC_SIGNATURE(func_name)                                                         \
-	static void func_name(struct eval_ctx *ctx, const struct ast *ast, struct vut_str *out,    \
-			      size_t ast_node_id, int flags)
+	static void func_name(struct compiler_ctx *cctx, struct vut_str *out, size_t ast_node_id,  \
+			      int flags)
 
 DO_CALLS_FUNC_SIGNATURE(do_calls);
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
+	struct ast *ast = &cctx->ast;
+	struct eval_ctx *ctx = &cctx->eval_ctx;
 	struct scope *curr_scope = &VUT_VEC_AT(&ctx->scopes, curr_scope_id);
 
 	ast_node_id_t call_name_ast = ast_get_nth_child(ast, ast_node_id, 0);
@@ -161,11 +167,11 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 		} else {
 			ast_node_id_t call = ast_get_nth_child(ast, call_name_ast, 0);
 			assert(ast_get_type(ast, call) == CALL);
-			resolve_calls(ctx, ast, curr_scope_id, call);
+			resolve_calls(cctx, curr_scope_id, call);
 
 			call_name_str = vut_str_init(ctx->allocator);
 
-			do_calls(ctx, ast, &call_name_str, call, REDUCE_BLANKS);
+			do_calls(cctx, &call_name_str, call, REDUCE_BLANKS);
 
 			call_name = vut_sv_from_vut_str(&call_name_str);
 			allocated = true;
@@ -206,7 +212,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 
 			ast_node_id_t new_node = ast_get_nth_child(ast, ast_node_id, 1);
 
-			resolve_symbols(ctx, ast, curr_scope_id, new_node);
+			resolve_symbols(cctx, curr_scope_id, new_node);
 		} else if (symbol_info->type == ENTRY_EXTERNAL) {
 			ast_node_id_t symbol = ast_get_nth_child(ast, ast_node_id, 0);
 			ast_set_type(ast, symbol, FUNCTION);
@@ -224,7 +230,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 			VUT_SV_ARG(call_name));
 	}
 
-	resolve_calls_descent(ctx, ast, curr_scope_id, ast_node_id);
+	resolve_calls_descent(cctx, curr_scope_id, ast_node_id);
 
 exit:
 	if (allocated)
@@ -232,19 +238,21 @@ exit:
 }
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls) {
+	struct ast *ast = &cctx->ast;
 	switch (ast_get_type(ast, ast_node_id)) {
 	case ARGS:
 	case PROGRAM:
-		resolve_calls_descent(ctx, ast, curr_scope_id, ast_node_id);
+		resolve_calls_descent(cctx, curr_scope_id, ast_node_id);
 		break;
 	case CALL:;
-		int new_scope = find_scope_child_by_node(&ctx->scopes, curr_scope_id, ast_node_id);
+		int new_scope = find_scope_child_by_node(&cctx->eval_ctx.scopes, curr_scope_id,
+							 ast_node_id);
 		if (new_scope > 0)
 			curr_scope_id = new_scope;
 		else
 			fprintf(stderr, "ERROR: Could not find call scope for node %zu\n",
 				ast_node_id);
-		resolve_calls_call(ctx, ast, curr_scope_id, ast_node_id);
+		resolve_calls_call(cctx, curr_scope_id, ast_node_id);
 		break;
 	default:
 		break;
@@ -252,6 +260,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls) {
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_program) {
+	struct ast *ast = &cctx->ast;
 	for (size_t i = 0; i < ast_get_num_child(ast, ast_node_id); i++) {
 		size_t child_id = ast_get_nth_child(ast, ast_node_id, i);
 		int sub_flags = flags & ~(FIRST_CHILD | LAST_CHILD);
@@ -261,11 +270,13 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_program) {
 		if (i == ast_get_num_child(ast, ast_node_id) - 1) {
 			sub_flags |= LAST_CHILD;
 		}
-		do_calls(ctx, ast, out, child_id, sub_flags);
+		do_calls(cctx, out, child_id, sub_flags);
 	}
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
+	struct ast *ast = &cctx->ast;
+	struct eval_ctx *ctx = &cctx->eval_ctx;
 	if (ast_get_num_child(ast, ast_node_id) <= 1) {
 		return;
 	}
@@ -277,7 +288,7 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 		// writes the returns of the arguments calls to a temporary buffer,
 		// so any nested call will be resolved normally
 		struct vut_str tmp_out = vut_str_init(ctx->allocator);
-		do_calls(ctx, ast, &tmp_out, args, flags);
+		do_calls(cctx, &tmp_out, args, flags);
 
 		// find the extern function on the scope
 		struct scope *curr_scope = &VUT_VEC_AT(&ctx->scopes, 0);
@@ -302,13 +313,12 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 		}
 		vut_allocator_free(ctx->allocator, tmp_text);
 	} else {
-		do_calls(ctx, ast, out, args, flags);
+		do_calls(cctx, out, args, flags);
 	}
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_text) {
-	UNUSED(ctx);
-	struct vut_sv text = ast_get_text(ast, ast_node_id);
+	struct vut_sv text = ast_get_text(&cctx->ast, ast_node_id);
 
 	if ((flags & REDUCE_BLANKS) != 0) {
 		bool trim_left = (flags & FIRST_CHILD) != 0;
@@ -320,17 +330,17 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_text) {
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls) {
-	switch (ast_get_type(ast, ast_node_id)) {
+	switch (ast_get_type(&cctx->ast, ast_node_id)) {
 	case PROGRAM:
 	case ARGS:
-		do_calls_program(ctx, ast, out, ast_node_id, flags);
+		do_calls_program(cctx, out, ast_node_id, flags);
 		break;
 	case CALL:
-		do_calls_call(ctx, ast, out, ast_node_id, flags);
+		do_calls_call(cctx, out, ast_node_id, flags);
 		break;
 	case TEXT:
 	case LITERAL:
-		do_calls_text(ctx, ast, out, ast_node_id, flags);
+		do_calls_text(cctx, out, ast_node_id, flags);
 		break;
 	default:
 		break;
@@ -380,16 +390,17 @@ void unload_libs(struct loaded_lib *loaded_libs, struct vut_allocator alloc) {
 	vut_allocator_free(alloc, loaded_libs);
 }
 
-struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct sv_vec *libraries) {
+struct vut_str eval(struct compiler_ctx *cctx) {
+	struct eval_ctx *ctx = &cctx->eval_ctx;
 	struct scope base_scope = scope_new(0, -1, ctx->allocator);
 	VUT_VEC_PUT(&ctx->scopes, base_scope);
 
-	struct loaded_lib *loaded_libs = load_libs(ctx, libraries);
-	resolve_symbols(ctx, ast, 0, 0);
-	resolve_calls(ctx, ast, 0, 0);
+	struct loaded_lib *loaded_libs = load_libs(ctx, &cctx->libraries);
+	resolve_symbols(cctx, 0, 0);
+	resolve_calls(cctx, 0, 0);
 
 	struct vut_str str_out = vut_str_init(ctx->allocator);
-	do_calls(ctx, ast, &str_out, 0, REDUCE_BLANKS);
+	do_calls(cctx, &str_out, 0, REDUCE_BLANKS);
 
 	unload_libs(loaded_libs, ctx->allocator);
 

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -77,6 +77,17 @@ static struct namespace_entry *find_symbol_on_scopes(const struct eval_ctx_scope
 	return NULL;
 }
 
+static int find_scope_by_ast_node(const struct eval_ctx_scopes_t *scope_array,
+				  ast_node_id_t ast_node) {
+	for (size_t i = 0; i < scope_array->len; i++) {
+		struct scope *s = &VUT_VEC_AT(scope_array, i);
+		if (s->node == ast_node)
+			return i;
+	}
+
+	return -1;
+}
+
 static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size_t scope_id,
 				    ast_node_id_t ast_node) {
 	const struct scope *curr_scope = &VUT_VEC_AT(scopes, scope_id);
@@ -292,14 +303,21 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 		struct scope *curr_scope = &VUT_VEC_AT(&ctx->scopes, 0);
 		struct namespace_entry *symbol_info =
 			find_symbol_on_scopes(&ctx->scopes, curr_scope, ast_get_text(ast, symbol));
+		int curr_scope_id = find_scope_by_ast_node(&ctx->scopes, ast_node);
+
+		assert(curr_scope_id != -1);
 
 		// expose context to external function
-		char *tmp_text = vut_str_move_to_cstr(&tmp_out);
-		struct _call_ctx cctx = { .arg_text = tmp_text };
-		struct return_value call_return = symbol_info->as.func(&cctx);
+		struct _call_ctx call_ctx = {
+			.arg_text = vut_str_move_to_cstr(&tmp_out),
+			.scope_id = curr_scope_id,
+			.ast_node = ast_node,
+			.compiler_ctx = cctx,
+		};
+
+		struct return_value call_return = symbol_info->as.func(&call_ctx);
 
 		// put the extern function call return on the out str
-
 		if ((flags & REDUCE_BLANKS) != 0) {
 			vut_str_put_blank_reduced_cstr(out, call_return.ptr, true, true);
 		} else {
@@ -309,7 +327,6 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 		if (call_return.free) {
 			free(call_return.ptr);
 		}
-		vut_allocator_free(ctx->allocator, tmp_text);
 	} else {
 		do_calls(cctx, out, args, flags);
 	}

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -88,6 +88,12 @@ static int find_scope_by_ast_node(const struct eval_ctx_scopes_t *scope_array,
 	return -1;
 }
 
+struct namespace_entry *eval_find_symbol_on_scopes(const struct eval_ctx *ctx, size_t curr_scope,
+						   const struct vut_sv name) {
+	struct scope *sp = &VUT_VEC_AT(&ctx->scopes, curr_scope);
+	return find_symbol_on_scopes(&ctx->scopes, sp, name);
+}
+
 static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size_t scope_id,
 				    ast_node_id_t ast_node) {
 	const struct scope *curr_scope = &VUT_VEC_AT(scopes, scope_id);

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -8,6 +8,7 @@
 #include <vutils/system_allocator.h>
 #include <vutils/vec.h>
 
+#include "ast.h"
 #include "eval.h"
 #include "extern_library.h"
 #include "library_loader.h"
@@ -417,15 +418,21 @@ struct vut_str eval(struct compiler_ctx *cctx) {
 	VUT_VEC_PUT(&ctx->scopes, base_scope);
 
 	struct loaded_lib *loaded_libs = load_libs(ctx, &cctx->libraries);
-	resolve_symbols(cctx, 0, 0);
-	resolve_calls(cctx, 0, 0);
 
 	struct vut_str str_out = vut_str_init(ctx->allocator);
-	do_calls(cctx, &str_out, 0, REDUCE_BLANKS);
+	eval_node(cctx, 0, 0, &str_out);
 
 	unload_libs(loaded_libs, ctx->allocator);
 
 	return str_out;
+}
+
+void eval_node(struct compiler_ctx *cctx, ast_node_id_t ast_node, size_t scope_id,
+	       struct vut_str *ret_str) {
+	resolve_symbols(cctx, scope_id, ast_node);
+	resolve_calls(cctx, scope_id, ast_node);
+
+	do_calls(cctx, ret_str, ast_node, REDUCE_BLANKS);
 }
 
 void eval_dot(const struct eval_ctx *ctx, FILE *stream) {

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -78,7 +78,7 @@ static struct namespace_entry *find_symbol_on_scopes(const struct eval_ctx_scope
 }
 
 static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size_t scope_id,
-				    size_t ast_node_id) {
+				    ast_node_id_t ast_node) {
 	const struct scope *curr_scope = &VUT_VEC_AT(scopes, scope_id);
 	int call_scope = -1;
 
@@ -86,7 +86,7 @@ static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size
 		size_t tmp_scope_id = VUT_VEC_AT(&curr_scope->childs, i);
 		struct scope *tmp_scope = &VUT_VEC_AT(scopes, tmp_scope_id);
 
-		if (tmp_scope->node == ast_node_id)
+		if (tmp_scope->node == ast_node)
 			call_scope = tmp_scope_id;
 	}
 
@@ -94,13 +94,14 @@ static int find_scope_child_by_node(const struct eval_ctx_scopes_t *scopes, size
 }
 
 #define RESOLVE_FUNC_SIGNATURE(func_name)                                                          \
-	static void func_name(struct compiler_ctx *cctx, size_t curr_scope_id, size_t ast_node_id)
+	static void func_name(struct compiler_ctx *cctx, size_t curr_scope_id,                     \
+			      ast_node_id_t ast_node)
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols);
 
 RESOLVE_FUNC_SIGNATURE(resolve_symbols_descent) {
-	for (size_t i = 0; i < ast_get_num_child(&cctx->ast, ast_node_id); i++) {
-		resolve_symbols(cctx, curr_scope_id, ast_get_nth_child(&cctx->ast, ast_node_id, i));
+	for (size_t i = 0; i < ast_get_num_child(&cctx->ast, ast_node); i++) {
+		resolve_symbols(cctx, curr_scope_id, ast_get_nth_child(&cctx->ast, ast_node, i));
 	}
 }
 
@@ -108,12 +109,12 @@ RESOLVE_FUNC_SIGNATURE(resolve_symbols_assignment) {
 	struct scope *curr_scope = &VUT_VEC_AT(&cctx->eval_ctx.scopes, curr_scope_id);
 
 	struct ast *ast = &cctx->ast;
-	struct vut_sv name = ast_get_text(ast, ast_get_nth_child(ast, ast_node_id, 0));
+	struct vut_sv name = ast_get_text(ast, ast_get_nth_child(ast, ast_node, 0));
 	struct namespace_entry entry = {
 		.name = name,
 		.type = ENTRY_INTERNAL,
-		.as.ast_node_id = ast_get_num_child(ast, ast_node_id) > 1
-					  ? (int)ast_get_nth_child(ast, ast_node_id, 1)
+		.as.ast_node_id = ast_get_num_child(ast, ast_node) > 1
+					  ? (int)ast_get_nth_child(ast, ast_node, 1)
 					  : -1,
 	};
 
@@ -123,13 +124,13 @@ RESOLVE_FUNC_SIGNATURE(resolve_symbols_assignment) {
 RESOLVE_FUNC_SIGNATURE(resolve_symbols) {
 	struct ast *ast = &cctx->ast;
 	struct eval_ctx *ctx = &cctx->eval_ctx;
-	if (ast_get_type(ast, ast_node_id) == ASSIGNMENT) {
-		resolve_symbols_assignment(cctx, curr_scope_id, ast_node_id);
+	if (ast_get_type(ast, ast_node) == ASSIGNMENT) {
+		resolve_symbols_assignment(cctx, curr_scope_id, ast_node);
 	} else {
-		if (ast_get_type(ast, ast_node_id) == CALL)
-			curr_scope_id = add_scope_child(&ctx->scopes, curr_scope_id, ast_node_id,
+		if (ast_get_type(ast, ast_node) == CALL)
+			curr_scope_id = add_scope_child(&ctx->scopes, curr_scope_id, ast_node,
 							ctx->allocator);
-		resolve_symbols_descent(cctx, curr_scope_id, ast_node_id);
+		resolve_symbols_descent(cctx, curr_scope_id, ast_node);
 	}
 }
 
@@ -137,14 +138,14 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls);
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls_descent) {
 	struct ast *ast = &cctx->ast;
-	for (size_t i = 0; i < ast_get_num_child(ast, ast_node_id); i++) {
-		resolve_calls(cctx, curr_scope_id, ast_get_nth_child(ast, ast_node_id, i));
+	for (size_t i = 0; i < ast_get_num_child(ast, ast_node); i++) {
+		resolve_calls(cctx, curr_scope_id, ast_get_nth_child(ast, ast_node, i));
 	}
 }
 
 #define DO_CALLS_FUNC_SIGNATURE(func_name)                                                         \
-	static void func_name(struct compiler_ctx *cctx, struct vut_str *out, size_t ast_node_id,  \
-			      int flags)
+	static void func_name(struct compiler_ctx *cctx, struct vut_str *out,                      \
+			      ast_node_id_t ast_node, int flags)
 
 DO_CALLS_FUNC_SIGNATURE(do_calls);
 
@@ -153,7 +154,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 	struct eval_ctx *ctx = &cctx->eval_ctx;
 	struct scope *curr_scope = &VUT_VEC_AT(&ctx->scopes, curr_scope_id);
 
-	ast_node_id_t call_name_ast = ast_get_nth_child(ast, ast_node_id, 0);
+	ast_node_id_t call_name_ast = ast_get_nth_child(ast, ast_node, 0);
 	assert(ast_get_type(ast, call_name_ast) == SYMBOL);
 
 	bool allocated = false;
@@ -182,10 +183,9 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 
 	if (symbol_info != NULL) {
 		if (symbol_info->type == ENTRY_INTERNAL) {
-			if (ast_get_num_child(ast, ast_node_id) > 1) {
+			if (ast_get_num_child(ast, ast_node) > 1) {
 				if (symbol_info->as.ast_node_id < 0) {
-					struct ast_node *node =
-						&VUT_VEC_AT(&ast->nodes, ast_node_id);
+					struct ast_node *node = &VUT_VEC_AT(&ast->nodes, ast_node);
 					node->childs.len--;
 					goto exit;
 				}
@@ -193,7 +193,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 				ast_node_id_t symbol_args =
 					ast_copy_node(ast, symbol_info->as.ast_node_id);
 
-				ast_node_id_t all_args = ast_get_nth_child(ast, ast_node_id, 1);
+				ast_node_id_t all_args = ast_get_nth_child(ast, ast_node, 1);
 				for (size_t i = 0; i < ast_get_num_child(ast, symbol_args); i++) {
 					ast_node_id_t child =
 						ast_get_nth_child(ast, symbol_args, i);
@@ -202,27 +202,26 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 						ast_set_nth_child(ast, symbol_args, i, all_args);
 					}
 				}
-				ast_set_nth_child(ast, ast_node_id, 1, symbol_args);
+				ast_set_nth_child(ast, ast_node, 1, symbol_args);
 			} else {
 				if (symbol_info->as.ast_node_id >= 0) {
-					ast_add_child(ast, ast_node_id,
-						      symbol_info->as.ast_node_id);
+					ast_add_child(ast, ast_node, symbol_info->as.ast_node_id);
 				}
 			}
 
-			ast_node_id_t new_node = ast_get_nth_child(ast, ast_node_id, 1);
+			ast_node_id_t new_node = ast_get_nth_child(ast, ast_node, 1);
 
 			resolve_symbols(cctx, curr_scope_id, new_node);
 		} else if (symbol_info->type == ENTRY_EXTERNAL) {
-			ast_node_id_t symbol = ast_get_nth_child(ast, ast_node_id, 0);
+			ast_node_id_t symbol = ast_get_nth_child(ast, ast_node, 0);
 			ast_set_type(ast, symbol, FUNCTION);
 
-			if (ast_get_num_child(ast, ast_node_id) <= 1) {
+			if (ast_get_num_child(ast, ast_node) <= 1) {
 				// ensure that the call node has an ARGS node
 				// to prevent it from being skipped during evaluation
 				size_t args_node_id =
 					ast_add_node(ast, ast_node_new_nvl(ARGS, ast->allocator));
-				ast_add_child(ast, ast_node_id, args_node_id);
+				ast_add_child(ast, ast_node, args_node_id);
 			}
 		}
 	} else {
@@ -230,7 +229,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 			VUT_SV_ARG(call_name));
 	}
 
-	resolve_calls_descent(cctx, curr_scope_id, ast_node_id);
+	resolve_calls_descent(cctx, curr_scope_id, ast_node);
 
 exit:
 	if (allocated)
@@ -239,20 +238,19 @@ exit:
 
 RESOLVE_FUNC_SIGNATURE(resolve_calls) {
 	struct ast *ast = &cctx->ast;
-	switch (ast_get_type(ast, ast_node_id)) {
+	switch (ast_get_type(ast, ast_node)) {
 	case ARGS:
 	case PROGRAM:
-		resolve_calls_descent(cctx, curr_scope_id, ast_node_id);
+		resolve_calls_descent(cctx, curr_scope_id, ast_node);
 		break;
 	case CALL:;
-		int new_scope = find_scope_child_by_node(&cctx->eval_ctx.scopes, curr_scope_id,
-							 ast_node_id);
+		int new_scope =
+			find_scope_child_by_node(&cctx->eval_ctx.scopes, curr_scope_id, ast_node);
 		if (new_scope > 0)
 			curr_scope_id = new_scope;
 		else
-			fprintf(stderr, "ERROR: Could not find call scope for node %zu\n",
-				ast_node_id);
-		resolve_calls_call(cctx, curr_scope_id, ast_node_id);
+			fprintf(stderr, "ERROR: Could not find call scope for node %u\n", ast_node);
+		resolve_calls_call(cctx, curr_scope_id, ast_node);
 		break;
 	default:
 		break;
@@ -261,13 +259,13 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls) {
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_program) {
 	struct ast *ast = &cctx->ast;
-	for (size_t i = 0; i < ast_get_num_child(ast, ast_node_id); i++) {
-		size_t child_id = ast_get_nth_child(ast, ast_node_id, i);
+	for (size_t i = 0; i < ast_get_num_child(ast, ast_node); i++) {
+		size_t child_id = ast_get_nth_child(ast, ast_node, i);
 		int sub_flags = flags & ~(FIRST_CHILD | LAST_CHILD);
 		if (i == 0) {
 			sub_flags |= FIRST_CHILD;
 		}
-		if (i == ast_get_num_child(ast, ast_node_id) - 1) {
+		if (i == ast_get_num_child(ast, ast_node) - 1) {
 			sub_flags |= LAST_CHILD;
 		}
 		do_calls(cctx, out, child_id, sub_flags);
@@ -277,12 +275,12 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_program) {
 DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 	struct ast *ast = &cctx->ast;
 	struct eval_ctx *ctx = &cctx->eval_ctx;
-	if (ast_get_num_child(ast, ast_node_id) <= 1) {
+	if (ast_get_num_child(ast, ast_node) <= 1) {
 		return;
 	}
 
-	ast_node_id_t symbol = ast_get_nth_child(ast, ast_node_id, 0);
-	ast_node_id_t args = ast_get_nth_child(ast, ast_node_id, 1);
+	ast_node_id_t symbol = ast_get_nth_child(ast, ast_node, 0);
+	ast_node_id_t args = ast_get_nth_child(ast, ast_node, 1);
 
 	if (ast_get_type(ast, symbol) == FUNCTION) {
 		// writes the returns of the arguments calls to a temporary buffer,
@@ -297,7 +295,7 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 
 		// expose context to external function
 		char *tmp_text = vut_str_move_to_cstr(&tmp_out);
-		struct _call_ctx cctx = { .text = tmp_text };
+		struct _call_ctx cctx = { .arg_text = tmp_text };
 		struct return_value call_return = symbol_info->as.func(&cctx);
 
 		// put the extern function call return on the out str
@@ -318,7 +316,7 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_call) {
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls_text) {
-	struct vut_sv text = ast_get_text(&cctx->ast, ast_node_id);
+	struct vut_sv text = ast_get_text(&cctx->ast, ast_node);
 
 	if ((flags & REDUCE_BLANKS) != 0) {
 		bool trim_left = (flags & FIRST_CHILD) != 0;
@@ -330,17 +328,17 @@ DO_CALLS_FUNC_SIGNATURE(do_calls_text) {
 }
 
 DO_CALLS_FUNC_SIGNATURE(do_calls) {
-	switch (ast_get_type(&cctx->ast, ast_node_id)) {
+	switch (ast_get_type(&cctx->ast, ast_node)) {
 	case PROGRAM:
 	case ARGS:
-		do_calls_program(cctx, out, ast_node_id, flags);
+		do_calls_program(cctx, out, ast_node, flags);
 		break;
 	case CALL:
-		do_calls_call(cctx, out, ast_node_id, flags);
+		do_calls_call(cctx, out, ast_node, flags);
 		break;
 	case TEXT:
 	case LITERAL:
-		do_calls_text(cctx, out, ast_node_id, flags);
+		do_calls_text(cctx, out, ast_node, flags);
 		break;
 	default:
 		break;

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -46,7 +46,7 @@ struct eval_ctx eval_ctx_new(struct vut_allocator allocator);
 
 struct sv_vec VUT_VEC_DEF(struct vut_sv);
 
-struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct sv_vec *libraries);
+struct vut_str eval(struct compiler_ctx *cctx);
 
 void eval_dot(const struct eval_ctx *ctx, FILE *stream);
 

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -50,4 +50,7 @@ struct vut_str eval(struct compiler_ctx *cctx);
 
 void eval_dot(const struct eval_ctx *ctx, FILE *stream);
 
+struct namespace_entry *eval_find_symbol_on_scopes(const struct eval_ctx *ctx, size_t curr_scope,
+						   const struct vut_sv name);
+
 #endif // __EVAL_H__

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -48,6 +48,9 @@ struct sv_vec VUT_VEC_DEF(struct vut_sv);
 
 struct vut_str eval(struct compiler_ctx *cctx);
 
+void eval_node(struct compiler_ctx *cctx, ast_node_id_t ast_node, size_t scope_id,
+	       struct vut_str *ret_str);
+
 void eval_dot(const struct eval_ctx *ctx, FILE *stream);
 
 struct namespace_entry *eval_find_symbol_on_scopes(const struct eval_ctx *ctx, size_t curr_scope,

--- a/subprojects/vinumc/include/vinumc/extern_library.h
+++ b/subprojects/vinumc/include/vinumc/extern_library.h
@@ -24,5 +24,6 @@ struct loaded_lib {
 };
 
 struct return_value ctx_get_arg(call_ctx ctx);
+struct return_value ctx_eval_symbol(call_ctx ctx, const char *name);
 
 #endif //__EXTERN_LIBRARY_H__

--- a/subprojects/vinumc/include/vinumc/extern_library.h
+++ b/subprojects/vinumc/include/vinumc/extern_library.h
@@ -23,6 +23,6 @@ struct loaded_lib {
 	struct extern_function *functions;
 };
 
-struct return_value ctx_get_text(call_ctx ctx);
+struct return_value ctx_get_arg(call_ctx ctx);
 
 #endif //__EXTERN_LIBRARY_H__

--- a/subprojects/vinumc/libvinumc.c
+++ b/subprojects/vinumc/libvinumc.c
@@ -32,10 +32,10 @@ void compiler_parse(struct compiler_ctx *ctx, struct vut_str *program) {
 }
 
 struct vut_str compiler_eval(struct compiler_ctx *ctx) {
-	return eval(&ctx->eval_ctx, &ctx->ast, &ctx->libraries);
+	return eval(ctx);
 }
 
 struct vut_str compiler_compile(struct compiler_ctx *ctx, struct vut_str *program) {
 	compiler_parse(ctx, program);
-	return compiler_eval(ctx);
+	return eval(ctx);
 }

--- a/subprojects/vinumc/tests/library_test.c
+++ b/subprojects/vinumc/tests/library_test.c
@@ -41,6 +41,29 @@ void test_call_no_args(struct vunit_test_ctx *ctx) {
 	VUNIT_ASSERT_STREQ(ctx, out, "()");
 }
 
+void test_call_eval_symbol(struct vunit_test_ctx *ctx) {
+	const char *out = compile_program_with_testlib("[author: Lorem Ipsum]\n"
+						       "[author_last_name]\n",
+						       ctx->allocator);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "Ipsum");
+}
+
+void test_call_eval_symbol_inside(struct vunit_test_ctx *ctx) {
+	const char *out = compile_program_with_testlib("[author_last_name [author: Lorem Ipsum]]\n",
+						       ctx->allocator);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "Ipsum");
+}
+
+void test_call_eval_extern_symbol(struct vunit_test_ctx *ctx) {
+	const char *out = compile_program_with_testlib("[author_last_name]\n"
+						       "[author: Lorem [parenthesize Ipsum]]\n",
+						       ctx->allocator);
+
+	VUNIT_ASSERT_STREQ(ctx, out, "(Ipsum)");
+}
+
 struct vunit_test tests[] = {
 	{ .name = "Test extern library call", .test_func = test_call },
 	{ .name = "Test extern library call inside call", .test_func = test_nested_call },
@@ -48,6 +71,19 @@ struct vunit_test tests[] = {
 	{
 		.name = "Test extern library call with no arguments",
 		.test_func = test_call_no_args,
+	},
+	{
+		.name = "Test extern library call that search symbol by name",
+		.test_func = test_call_eval_symbol,
+	},
+	{
+		.name = "Test extern library call that search symbol by name declared in function "
+			"arg",
+		.test_func = test_call_eval_symbol_inside,
+	},
+	{
+		.name = "Test extern library call that call extern symbol by name",
+		.test_func = test_call_eval_extern_symbol,
 	},
 	{},
 };

--- a/subprojects/vinumc/tests/testlib.c
+++ b/subprojects/vinumc/tests/testlib.c
@@ -25,9 +25,24 @@ struct return_value parenthesize(call_ctx ctx) {
 	return (struct return_value){ .ptr = result, .free = true, .status = true };
 }
 
+struct return_value author_last_name(call_ctx ctx) {
+	struct return_value ret = ctx_eval_symbol(ctx, "author");
+	if (!ret.status) {
+		return ret;
+	}
+
+	char *last_space = strrchr(ret.ptr, ' ');
+	if (last_space) {
+		memmove(ret.ptr, last_space + 1, strlen(last_space) + 2);
+	}
+
+	return ret;
+}
+
 struct extern_function *expose_library() {
 	static struct extern_function lib[] = { { "return_arg", return_arg },
 						{ "parenthesize", parenthesize },
+						{ "author_last_name", author_last_name },
 						{} };
 	return lib;
 }

--- a/subprojects/vinumc/tests/testlib.c
+++ b/subprojects/vinumc/tests/testlib.c
@@ -4,11 +4,11 @@
 #include <vinumc/extern_library.h>
 
 struct return_value return_arg(call_ctx ctx) {
-	return ctx_get_text(ctx);
+	return ctx_get_arg(ctx);
 }
 
 struct return_value parenthesize(call_ctx ctx) {
-	struct return_value ret = ctx_get_text(ctx);
+	struct return_value ret = ctx_get_arg(ctx);
 	if (!ret.status) {
 		return ret;
 	}

--- a/subprojects/vinumc/v_lib.c
+++ b/subprojects/vinumc/v_lib.c
@@ -1,6 +1,6 @@
 #include "v_lib.h"
 #include "extern_library.h"
 
-struct return_value ctx_get_text(call_ctx ctx) {
+struct return_value ctx_get_arg(call_ctx ctx) {
 	return (struct return_value){ .ptr = ctx->text, .status = true };
 }

--- a/subprojects/vinumc/v_lib.c
+++ b/subprojects/vinumc/v_lib.c
@@ -2,5 +2,5 @@
 #include "extern_library.h"
 
 struct return_value ctx_get_arg(call_ctx ctx) {
-	return (struct return_value){ .ptr = ctx->text, .status = true };
+	return (struct return_value){ .ptr = ctx->arg_text, .status = true };
 }

--- a/subprojects/vinumc/v_lib.c
+++ b/subprojects/vinumc/v_lib.c
@@ -1,6 +1,22 @@
-#include "v_lib.h"
+#include <vutils/system_allocator.h>
+
 #include "extern_library.h"
+#include "v_lib.h"
 
 struct return_value ctx_get_arg(call_ctx ctx) {
 	return (struct return_value){ .ptr = ctx->arg_text, .status = true };
+}
+
+struct return_value ctx_eval_symbol(call_ctx ctx, const char *name) {
+	struct compiler_ctx *comp_ctx = ctx->compiler_ctx;
+	struct namespace_entry *symbol_info = eval_find_symbol_on_scopes(
+		&comp_ctx->eval_ctx, ctx->scope_id, vut_sv_from_cstr(name));
+	struct vut_str text = vut_str_init(vut_get_system_allocator());
+	eval_node(comp_ctx, symbol_info->as.ast_node_id, ctx->scope_id, &text);
+
+	return (struct return_value){
+		.ptr = vut_str_move_to_cstr(&text),
+		.status = true,
+		.free = true,
+	};
 }

--- a/subprojects/vinumc/v_lib.h
+++ b/subprojects/vinumc/v_lib.h
@@ -2,7 +2,7 @@
 #define __V_LIB_H__
 
 struct _call_ctx {
-	char *text;
+	char *arg_text;
 };
 
 #endif //__V_LIB_H__

--- a/subprojects/vinumc/v_lib.h
+++ b/subprojects/vinumc/v_lib.h
@@ -1,8 +1,15 @@
 #ifndef __V_LIB_H__
 #define __V_LIB_H__
 
+#include <stdbool.h>
+
+#include "libvinumc.h"
+
 struct _call_ctx {
 	char *arg_text;
+	struct compiler_ctx *compiler_ctx;
+	size_t scope_id;
+	size_t ast_node;
 };
 
 #endif //__V_LIB_H__


### PR DESCRIPTION
This allow the external library to get arguments from the function call by index and to get any name available on the call scope