### PR TITLE
Vunit: Update README.md with the new way of declaring a test suite

### DIFF
--- a/subprojects/vunit/README.md
+++ b/subprojects/vunit/README.md
@@ -19,10 +19,12 @@ void test(struct vunit_test_ctx *ctx) {
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
 
-VUNIT_TEST_SUITE("suite",
+struct vunit_test tests[] = {
 	{"Basic test", test},
 	{},
-)
+};
+
+VUNIT_TEST_SUITE(tests)
 ```
 
 For the output it uses the [TAP](https://testanything.org/) protocol.


### PR DESCRIPTION
The README is showing the old way, update it.