### PR TITLE
vutils/arena_allocator: Simplify arena implementation

### DIFF
--- a/subprojects/vutils/arena_allocator.c
+++ b/subprojects/vutils/arena_allocator.c
@@ -6,13 +6,12 @@
 #include "allocator.h"
 #include "arena_allocator.h"
 
-struct vut_arena vut_arena_new(struct vut_allocator *base_allocator,
-			       size_t common_max_allocation_size) {
-	struct vut_arena new_arena = {
-		.allocations = VUT_VEC_INIT(struct vut_arena_allocations, base_allocator),
-		.base_allocator = base_allocator,
-		.common_max_allocation_size = common_max_allocation_size,
-	};
+struct vut_arena vut_arena_new(struct vut_allocator *base_allocator, size_t arena_size) {
+	struct vut_arena new_arena = {};
+	new_arena.base_allocator = base_allocator;
+	new_arena.buffer_size = arena_size;
+	new_arena.buffer = vut_allocator_malloc(base_allocator, sizeof(uint8_t), arena_size);
+	new_arena.free_ptr = new_arena.buffer;
 	return new_arena;
 }
 
@@ -49,40 +48,16 @@ struct vut_allocator vut_arena_to_vut_allocator(struct vut_arena *arena) {
 	return new_allocator;
 }
 
-static void append_new_buffer(struct vut_arena *arena, size_t buffer_size) {
-	struct arena_buffer new = { 0 };
-	new.buffer = vut_allocator_malloc(arena->base_allocator, buffer_size, 1);
-	VUT_VEC_PUT(&arena->allocations, new);
-}
-
-static struct arena_buffer get_last_buffer(struct vut_arena *arena) {
-	return VUT_VEC_AT(&arena->allocations, arena->allocations.len - 1);
-}
-
 void *vut_arena_malloc(struct vut_arena *arena, size_t bytes, size_t times) {
 	if (bytes * times == 0)
 		return NULL;
-	size_t allocation_size = bytes * times;
 
-	if (arena->allocations.len == 0)
-		append_new_buffer(arena, arena->common_max_allocation_size);
+	assert(arena->buffer - arena->free_ptr <= (long)arena->buffer_size);
 
-	struct arena_buffer last_buffer = get_last_buffer(arena);
+	uint8_t *ret = arena->free_ptr;
+	arena->free_ptr += bytes * times;
 
-	if (allocation_size > arena->common_max_allocation_size) {
-		append_new_buffer(arena, allocation_size);
-		void *ptr = get_last_buffer(arena).buffer;
-		append_new_buffer(arena, arena->common_max_allocation_size);
-		return ptr;
-	} else if (arena->common_max_allocation_size - last_buffer.used < allocation_size) {
-		append_new_buffer(arena, arena->common_max_allocation_size);
-		last_buffer = get_last_buffer(arena);
-	}
-
-	void *ptr = &last_buffer.buffer[last_buffer.used];
-	last_buffer.used += allocation_size;
-
-	return ptr;
+	return ret;
 }
 
 void *vut_arena_calloc(struct vut_arena *arena, size_t bytes, size_t times) {
@@ -99,14 +74,12 @@ void *vut_arena_realloc(struct vut_arena *arena, void *old_ptr, size_t bytes, si
 		return NULL;
 
 	void *ptr = vut_arena_malloc(arena, bytes, times);
-	memcpy(ptr, old_ptr, bytes * times);
+	if (old_ptr != NULL)
+		memcpy(ptr, old_ptr, bytes * times);
 
 	return ptr;
 }
 
 void vut_arena_free_all(struct vut_arena *arena) {
-	VUT_VEC_FOREACH(&arena->allocations, _, struct arena_buffer * buffer) {
-		vut_allocator_free(arena->base_allocator, buffer->buffer);
-	}
-	VUT_VEC_FREE(&arena->allocations);
+	vut_allocator_free(arena->base_allocator, arena->buffer);
 }

--- a/subprojects/vutils/include/vutils/arena_allocator.h
+++ b/subprojects/vutils/include/vutils/arena_allocator.h
@@ -7,17 +7,11 @@
 #include "allocator.h"
 #include "vec.h"
 
-struct arena_buffer {
-	uint8_t *buffer;
-	size_t used;
-};
-
-struct vut_arena_allocations VUT_VEC_DEF(struct arena_buffer);
-
 struct vut_arena {
-	struct vut_arena_allocations allocations;
 	struct vut_allocator *base_allocator;
-	size_t common_max_allocation_size;
+	uint8_t *buffer;
+	size_t buffer_size;
+	uint8_t *free_ptr;
 };
 
 struct vut_arena vut_arena_new(struct vut_allocator *base_allocator,


### PR DESCRIPTION
An arena is just a contiguous area of memory. We don't need all that complexity of having a list or memory pools.