### PR TITLE
vinumc/meson.build: Isolate parser dependencies

### DIFF
--- a/subprojects/vinumc/meson.build
+++ b/subprojects/vinumc/meson.build
@@ -47,7 +47,7 @@ parser_lib = static_library('vinumc_parser',
 
 parser_dep = declare_dependency(
   link_with : parser_lib,
-  sources : [bison_gen, lex_gen],
+  sources : [bison_gen[1], lex_gen[1]],
   include_directories : generated_inc,
   dependencies : vutils_dep,
 )
@@ -87,13 +87,12 @@ libvinumc = library(
 libvinumc_dep = declare_dependency(
   link_with: libvinumc,
   include_directories: external_inc,
-  dependencies: parser_dep,
 )
 
 libvinumc_dep_priv = declare_dependency(
   link_with: libvinumc,
+  sources : [bison_gen[1], lex_gen[1]],
   include_directories: [external_inc, libvinumc.private_dir_include()],
-  dependencies: parser_dep,
 )
 
 vinumc = executable(


### PR DESCRIPTION
Using `ninja -t graph`[1] I found out that the dry_*.c souces are being directly included in the libvinumc compilation. This is not necessary, as the the libvinumc already includes the parser_lib.

Furthermore, the parser_lib is being directly include in the vinumc and vin2dot binaries. THis is also not necessary, since the both programs include libvinumc.

With this second one fixed, we need to explicitly forward the dry_* headers on the libvinumc depency, since ast.h includes dry_flex.h.

[1]: https://ninja-build.org/manual.html#_running_ninja