### PR TITLE
vutils/allocator: Always pass struct vut_allocator by value

### DIFF
--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -5,7 +5,7 @@
 
 #include "ast.h"
 
-struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator *allocator) {
+struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator allocator) {
 	struct ast_node ret = { .type = type,
 				.text = text,
 				.childs = VUT_VEC_INIT(struct ast_node_childs_t, allocator) };
@@ -13,7 +13,7 @@ struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allo
 	return ret;
 }
 
-struct ast ast_new(struct vut_allocator *allocator) {
+struct ast ast_new(struct vut_allocator allocator) {
 	struct ast ret = {
 		.nodes = VUT_VEC_INIT(struct ast_nodes_t, allocator),
 		.allocator = allocator,

--- a/subprojects/vinumc/ast.h
+++ b/subprojects/vinumc/ast.h
@@ -22,17 +22,18 @@ struct ast_node {
 	struct ast_node_childs_t childs;
 };
 
-struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator *allocator);
+struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator allocator);
 #define ast_node_new_nvl(type, allocator) (ast_node_new((type), (struct vut_sv){ 0 }, (allocator)))
 
 struct ast_nodes_t VUT_VEC_DEF(struct ast_node);
 
 struct ast {
 	struct ast_nodes_t nodes;
-	struct vut_allocator *allocator;
+
+	struct vut_allocator allocator;
 };
 
-struct ast ast_new(struct vut_allocator *allocator);
+struct ast ast_new(struct vut_allocator allocator);
 
 const char *token_to_str(enum yytokentype token);
 ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node);

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -20,7 +20,7 @@ enum do_calls_flag {
 	LAST_CHILD = 1 << 2,
 };
 
-struct eval_ctx eval_ctx_new(struct vut_allocator *allocator) {
+struct eval_ctx eval_ctx_new(struct vut_allocator allocator) {
 	struct eval_ctx ret = {
 		.allocator = allocator,
 		.scopes = VUT_VEC_INIT(struct eval_ctx_scopes_t, allocator),
@@ -29,7 +29,7 @@ struct eval_ctx eval_ctx_new(struct vut_allocator *allocator) {
 	return ret;
 }
 
-static struct scope scope_new(ast_node_id_t node, int father, struct vut_allocator *allocator) {
+static struct scope scope_new(ast_node_id_t node, int father, struct vut_allocator allocator) {
 	struct scope new_scope = {
 		.father = father,
 		.node = node,
@@ -40,7 +40,7 @@ static struct scope scope_new(ast_node_id_t node, int father, struct vut_allocat
 }
 
 static size_t add_scope_child(struct eval_ctx_scopes_t *scope_array, size_t scope_id,
-			      ast_node_id_t node, struct vut_allocator *allocator) {
+			      ast_node_id_t node, struct vut_allocator allocator) {
 	size_t new_scope_id = scope_array->len;
 	struct scope new_scope = scope_new(node, scope_id, allocator);
 
@@ -368,7 +368,7 @@ struct loaded_lib *load_libs(struct eval_ctx *ctx, struct str_vec *libraries) {
 	return loaded_libs;
 }
 
-void unload_libs(struct loaded_lib *loaded_libs, struct vut_allocator *alloc) {
+void unload_libs(struct loaded_lib *loaded_libs, struct vut_allocator alloc) {
 	if (loaded_libs == NULL) {
 		return;
 	}

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -39,10 +39,10 @@ struct eval_ctx_scopes_t VUT_VEC_DEF(struct scope);
 
 struct eval_ctx {
 	struct eval_ctx_scopes_t scopes;
-	struct vut_allocator *allocator;
+	struct vut_allocator allocator;
 };
 
-struct eval_ctx eval_ctx_new(struct vut_allocator *allocator);
+struct eval_ctx eval_ctx_new(struct vut_allocator allocator);
 
 struct str_vec VUT_VEC_DEF(char *);
 

--- a/subprojects/vinumc/libvinumc.c
+++ b/subprojects/vinumc/libvinumc.c
@@ -1,7 +1,7 @@
 #include "libvinumc.h"
 #include "dry_flex.h"
 
-struct compiler_ctx compiler_ctx_init(struct vut_allocator *alloc) {
+struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc) {
 	struct compiler_ctx ctx = {
 		.ast = ast_new(alloc),
 		.eval_ctx = eval_ctx_new(alloc),

--- a/subprojects/vinumc/libvinumc.h
+++ b/subprojects/vinumc/libvinumc.h
@@ -2,6 +2,7 @@
 #define __LIBVINUMC_H__
 
 #include <vutils/allocator.h>
+#include <vutils/arena_allocator.h>
 #include <vutils/str.h>
 
 #include "ast.h"
@@ -16,10 +17,10 @@ struct compiler_ctx {
 	// that could be just one node
 	struct vut_str dry_flex_text_buffer;
 
-	struct vut_allocator *alloc;
+	struct vut_allocator alloc;
 };
 
-struct compiler_ctx compiler_ctx_init(struct vut_allocator *alloc);
+struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc);
 
 void compiler_parse(struct compiler_ctx *ctx, struct vut_str *program);
 struct vut_str compiler_eval(struct compiler_ctx *ctx);

--- a/subprojects/vinumc/tests/library_test.c
+++ b/subprojects/vinumc/tests/library_test.c
@@ -2,7 +2,7 @@
 
 #include "libvinumc.h"
 
-static char *compile_program_with_testlib(const char *prg_cstr, struct vut_allocator *alloc) {
+static char *compile_program_with_testlib(const char *prg_cstr, struct vut_allocator alloc) {
 	struct compiler_ctx comp = compiler_ctx_init(alloc);
 
 	struct vut_str prg = vut_str_init(alloc);
@@ -15,7 +15,7 @@ static char *compile_program_with_testlib(const char *prg_cstr, struct vut_alloc
 }
 
 void test_call(struct vunit_test_ctx *ctx) {
-	const char *out = compile_program_with_testlib("[return_arg test]\n", &ctx->allocator);
+	const char *out = compile_program_with_testlib("[return_arg test]\n", ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "test");
 }
@@ -23,20 +23,20 @@ void test_call(struct vunit_test_ctx *ctx) {
 void test_nested_call(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program_with_testlib("[a: This is a [return_arg Test!]!]\n"
 						       "[a]\n",
-						       &ctx->allocator);
+						       ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "This is a Test!!");
 }
 
 void test_empty_nested_call(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program_with_testlib("[return_arg [return_arg [return_arg]]]",
-						       &ctx->allocator);
+						       ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "");
 }
 
 void test_call_no_args(struct vunit_test_ctx *ctx) {
-	const char *out = compile_program_with_testlib("[parenthesize]", &ctx->allocator);
+	const char *out = compile_program_with_testlib("[parenthesize]", ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "()");
 }

--- a/subprojects/vinumc/tests/metaprog_test.c
+++ b/subprojects/vinumc/tests/metaprog_test.c
@@ -2,7 +2,7 @@
 
 #include "libvinumc.h"
 
-static char *compile_program(const char *prg_cstr, struct vut_allocator *alloc) {
+static char *compile_program(const char *prg_cstr, struct vut_allocator alloc) {
 	struct compiler_ctx comp = compiler_ctx_init(alloc);
 
 	struct vut_str prg = vut_str_init(alloc);
@@ -17,7 +17,7 @@ void test_call_name_returned_by_another_call(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program("[foo: bar]\n"
 					  "[bar: Hello World!]\n"
 					  "[[foo]]\n",
-					  &ctx->allocator);
+					  ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }

--- a/subprojects/vinumc/tests/simple_test.c
+++ b/subprojects/vinumc/tests/simple_test.c
@@ -2,7 +2,7 @@
 
 #include "libvinumc.h"
 
-static char *compile_program(const char *prg_cstr, struct vut_allocator *alloc) {
+static char *compile_program(const char *prg_cstr, struct vut_allocator alloc) {
 	struct compiler_ctx comp = compiler_ctx_init(alloc);
 
 	struct vut_str prg = vut_str_init(alloc);
@@ -16,7 +16,7 @@ static char *compile_program(const char *prg_cstr, struct vut_allocator *alloc) 
 void test_basic(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program("[a: Hello World!]\n"
 					  "[a]\n",
-					  &ctx->allocator);
+					  ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
@@ -24,7 +24,7 @@ void test_basic(struct vunit_test_ctx *ctx) {
 void test_define_later(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program("[a]\n"
 					  "[a: Hello World!]\n",
-					  &ctx->allocator);
+					  ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
@@ -32,7 +32,7 @@ void test_define_later(struct vunit_test_ctx *ctx) {
 void test_function_text_args(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program("[a: $*]\n"
 					  "[a Hello World!]\n",
-					  &ctx->allocator);
+					  ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }
@@ -41,7 +41,7 @@ void test_function_call_args(struct vunit_test_ctx *ctx) {
 	const char *out = compile_program("[a: Hello World!]\n"
 					  "[b: $*]\n"
 					  "[b [a]]\n",
-					  &ctx->allocator);
+					  ctx->allocator);
 
 	VUNIT_ASSERT_STREQ(ctx, out, "Hello World!");
 }

--- a/subprojects/vinumc/vinumc.c
+++ b/subprojects/vinumc/vinumc.c
@@ -17,7 +17,7 @@
 
 #define ARRAY_SIZE(arr) (sizeof((arr)) / sizeof(*(arr)))
 
-struct ctx ctx_new(struct vut_allocator *allocator) {
+struct ctx ctx_new(struct vut_allocator allocator) {
 	struct ctx ret = {
 		.compiler = compiler_ctx_init(allocator),
 		.alloc = allocator,

--- a/subprojects/vinumc/vinumc.h
+++ b/subprojects/vinumc/vinumc.h
@@ -15,9 +15,9 @@ struct ctx {
 
 	struct compiler_ctx compiler;
 
-	struct vut_allocator *alloc;
+	struct vut_allocator alloc;
 };
 
-struct ctx ctx_new(struct vut_allocator *allocator);
+struct ctx ctx_new(struct vut_allocator allocator);
 
 #endif // __VINUMC_H__

--- a/subprojects/vunit/vunit.c
+++ b/subprojects/vunit/vunit.c
@@ -25,7 +25,7 @@ static char *alloc_printf(struct vunit_test_ctx *ctx, const char *fmt, ...) {
 	assert(len >= 0);
 	len++;
 
-	ret = vut_allocator_malloc(&ctx->allocator, sizeof(*ret), len);
+	ret = vut_allocator_malloc(ctx->allocator, sizeof(*ret), len);
 	assert(ret != NULL);
 
 	va_start(ap, fmt);
@@ -195,10 +195,10 @@ static char *read_all_from_pipe(struct vunit_test_ctx *ctx, int fd) {
 
 	ssize_t read_len = 0;
 	size_t total_len = 0;
-	char *ret = vut_allocator_malloc(&ctx->allocator, sizeof(*ret), 1);
+	char *ret = vut_allocator_malloc(ctx->allocator, sizeof(*ret), 1);
 
 	while ((read_len = read(fd, tmp_buf, sizeof(tmp_buf))) > 0) {
-		ret = vut_allocator_realloc(&ctx->allocator, ret, sizeof(*ret),
+		ret = vut_allocator_realloc(ctx->allocator, ret, sizeof(*ret),
 					    total_len + read_len + 1);
 		memcpy(ret + total_len, tmp_buf, sizeof(*ret) * read_len);
 		total_len += read_len;
@@ -271,9 +271,10 @@ int vunit_run_vinumc(struct vunit_test_ctx *ctx, char *input, char **output, cha
 			close(rx_stderr);
 		}
 
-		VUNIT_ASSERT_NEQ(ctx, WIFEXITED(stat), 0);
-
-		return WEXITSTATUS(stat);
+		if (!WIFEXITED(stat))
+			return -1;
+		else
+			return WEXITSTATUS(stat);
 	} else {
 		if (input != NULL) {
 			int rx = father_to_child_pipe[0];
@@ -298,7 +299,7 @@ int vunit_run_vinumc(struct vunit_test_ctx *ctx, char *input, char **output, cha
 		}
 
 		char **args_to_send =
-			vut_allocator_malloc(&ctx->allocator, sizeof(*args_to_send), argc + 2);
+			vut_allocator_malloc(ctx->allocator, sizeof(*args_to_send), argc + 2);
 		VUNIT_ASSERT_NEQ(ctx, args_to_send, NULL);
 
 		// TODO: Get the absolute path
@@ -342,7 +343,7 @@ char *vunit_file_to_str(struct vunit_test_ctx *ctx, const char *file_path) {
 	VUNIT_ASSERT_NEQ(ctx, file_size, -1);
 	rewind(fp);
 
-	char *ret_str = vut_allocator_calloc(&ctx->allocator, file_size + 1, sizeof(*ret_str));
+	char *ret_str = vut_allocator_calloc(ctx->allocator, file_size + 1, sizeof(*ret_str));
 	VUNIT_ASSERT_NEQ(ctx, ret_str, NULL);
 
 	fread(ret_str, sizeof(*ret_str), file_size, fp);
@@ -360,7 +361,7 @@ int vunit_run_vinumcv(struct vunit_test_ctx *ctx, char *input, char **output, ch
 	char *curr_arg;
 	while ((curr_arg = va_arg(ap, char *)) != NULL) {
 		argc++;
-		argv = vut_allocator_realloc(&ctx->allocator, argv, sizeof(*argv), argc);
+		argv = vut_allocator_realloc(ctx->allocator, argv, sizeof(*argv), argc);
 		argv[argc - 1] = curr_arg;
 	}
 
@@ -375,6 +376,9 @@ void vunit_run_vinumc_ok(struct vunit_test_ctx *ctx, char *input, char **output,
 	int ret = vunit_run_vinumcv(ctx, input, output, &err, ap);
 	va_end(ap);
 
+	if (strlen(err) != 0) {
+		fprintf(stderr, "PROGRAM STDERR:\n%s\n", err);
+	}
 	VUNIT_ASSERT_EQ(ctx, ret, 0);
 	VUNIT_ASSERT_EQ(ctx, strlen(err), 0);
 }

--- a/subprojects/vutils/allocator.c
+++ b/subprojects/vutils/allocator.c
@@ -1,18 +1,18 @@
 #include "allocator.h"
 
-void *vut_allocator_malloc(struct vut_allocator *allocator, size_t bytes, size_t times) {
-	return allocator->funcs.malloc(allocator->base_allocator, bytes, times);
+void *vut_allocator_malloc(struct vut_allocator allocator, size_t bytes, size_t times) {
+	return allocator.funcs->malloc(allocator.base_allocator, bytes, times);
 }
 
-void *vut_allocator_calloc(struct vut_allocator *allocator, size_t bytes, size_t times) {
-	return allocator->funcs.calloc(allocator->base_allocator, bytes, times);
+void *vut_allocator_calloc(struct vut_allocator allocator, size_t bytes, size_t times) {
+	return allocator.funcs->calloc(allocator.base_allocator, bytes, times);
 }
 
-void *vut_allocator_realloc(struct vut_allocator *allocator, void *old_ptr, size_t bytes,
+void *vut_allocator_realloc(struct vut_allocator allocator, void *old_ptr, size_t bytes,
 			    size_t times) {
-	return allocator->funcs.realloc(allocator->base_allocator, old_ptr, bytes, times);
+	return allocator.funcs->realloc(allocator.base_allocator, old_ptr, bytes, times);
 }
 
-void vut_allocator_free(struct vut_allocator *allocator, void *ptr) {
-	allocator->funcs.free(allocator->base_allocator, ptr);
+void vut_allocator_free(struct vut_allocator allocator, void *ptr) {
+	allocator.funcs->free(allocator.base_allocator, ptr);
 }

--- a/subprojects/vutils/arena_allocator.c
+++ b/subprojects/vutils/arena_allocator.c
@@ -8,7 +8,7 @@
 
 #define ALIGN_UP(addr, align) ((((uintptr_t)(addr)) + ((align) - 1)) & ~((uintptr_t)((align) - 1)))
 
-struct vut_arena vut_arena_new(struct vut_allocator *base_allocator, size_t arena_size) {
+struct vut_arena vut_arena_new(struct vut_allocator base_allocator, size_t arena_size) {
 	struct vut_arena new_arena = {};
 	new_arena.base_allocator = base_allocator;
 	new_arena.buffer_size = arena_size;
@@ -44,7 +44,7 @@ static struct vut_allocator_funcs arena_allocator_funcs = {
 struct vut_allocator vut_arena_to_vut_allocator(struct vut_arena *arena) {
 	struct vut_allocator new_allocator = {
 		.base_allocator = arena,
-		.funcs = arena_allocator_funcs,
+		.funcs = &arena_allocator_funcs,
 	};
 
 	return new_allocator;

--- a/subprojects/vutils/futils.c
+++ b/subprojects/vutils/futils.c
@@ -7,7 +7,7 @@ long vut_fut_get_size_FILE(FILE *fp) {
 	return size;
 }
 
-struct vut_str vut_fut_read_all_FILE(FILE *fp, struct vut_allocator *alloc) {
+struct vut_str vut_fut_read_all_FILE(FILE *fp, struct vut_allocator alloc) {
 	static const int READ_BUFF_CAPACITY = 1024;
 
 	struct vut_str str = vut_str_init(alloc);

--- a/subprojects/vutils/include/vutils/allocator.h
+++ b/subprojects/vutils/include/vutils/allocator.h
@@ -13,13 +13,13 @@ struct vut_allocator_funcs {
 
 struct vut_allocator {
 	void *base_allocator;
-	struct vut_allocator_funcs funcs;
+	const struct vut_allocator_funcs *funcs;
 };
 
-void *vut_allocator_malloc(struct vut_allocator *allocator, size_t bytes, size_t times);
-void *vut_allocator_calloc(struct vut_allocator *allocator, size_t bytes, size_t times);
-void *vut_allocator_realloc(struct vut_allocator *allocator, void *old_ptr, size_t bytes,
+void *vut_allocator_malloc(struct vut_allocator allocator, size_t bytes, size_t times);
+void *vut_allocator_calloc(struct vut_allocator allocator, size_t bytes, size_t times);
+void *vut_allocator_realloc(struct vut_allocator allocator, void *old_ptr, size_t bytes,
 			    size_t times);
-void vut_allocator_free(struct vut_allocator *allocator, void *ptr);
+void vut_allocator_free(struct vut_allocator allocator, void *ptr);
 
 #endif // __VUT_ALLOCATOR_H__

--- a/subprojects/vutils/include/vutils/arena_allocator.h
+++ b/subprojects/vutils/include/vutils/arena_allocator.h
@@ -8,13 +8,13 @@
 #include "vec.h"
 
 struct vut_arena {
-	struct vut_allocator *base_allocator;
+	struct vut_allocator base_allocator;
 	uint8_t *buffer;
 	size_t buffer_size;
 	uint8_t *free_ptr;
 };
 
-struct vut_arena vut_arena_new(struct vut_allocator *base_allocator,
+struct vut_arena vut_arena_new(struct vut_allocator base_allocator,
 			       size_t common_max_allocation_size);
 struct vut_allocator vut_arena_to_vut_allocator(struct vut_arena *arena);
 

--- a/subprojects/vutils/include/vutils/futils.h
+++ b/subprojects/vutils/include/vutils/futils.h
@@ -6,6 +6,6 @@
 #include "str.h"
 
 long vut_fut_get_size_FILE(FILE *fp);
-struct vut_str vut_fut_read_all_FILE(FILE *fp, struct vut_allocator *alloc);
+struct vut_str vut_fut_read_all_FILE(FILE *fp, struct vut_allocator alloc);
 
 #endif // __VUT_FUTILS_H__

--- a/subprojects/vutils/include/vutils/str.h
+++ b/subprojects/vutils/include/vutils/str.h
@@ -11,9 +11,8 @@
 
 struct vut_str VUT_VEC_DEF(char);
 
-struct vut_str vut_str_init(struct vut_allocator *alloc);
-struct vut_str vut_str_from_vut_sv(struct vut_sv sv, struct vut_allocator *alloc);
-
+struct vut_str vut_str_init(struct vut_allocator alloc);
+struct vut_str vut_str_from_vut_sv(struct vut_sv sv, struct vut_allocator alloc);
 void vut_str_free(struct vut_str *str);
 
 void vut_str_put_cstr(struct vut_str *to, const char *from);

--- a/subprojects/vutils/include/vutils/system_allocator.h
+++ b/subprojects/vutils/include/vutils/system_allocator.h
@@ -5,6 +5,6 @@
 
 #include "allocator.h"
 
-struct vut_allocator *vut_get_system_allocator();
+struct vut_allocator vut_get_system_allocator();
 
 #endif // __VUT_SYSTEM_ALLOCATOR_H__

--- a/subprojects/vutils/include/vutils/vec.h
+++ b/subprojects/vutils/include/vutils/vec.h
@@ -9,7 +9,7 @@
 		base_type *base;                                                                   \
 		size_t len;                                                                        \
 		size_t capacity;                                                                   \
-		struct vut_allocator *allocator;                                                   \
+		struct vut_allocator allocator;                                                    \
 	}
 
 #define VUT_VEC_INIT(vec_type, allocator_obj)                                                      \

--- a/subprojects/vutils/str.c
+++ b/subprojects/vutils/str.c
@@ -2,11 +2,11 @@
 
 #include <str.h>
 
-struct vut_str vut_str_init(struct vut_allocator *alloc) {
+struct vut_str vut_str_init(struct vut_allocator alloc) {
 	return VUT_VEC_INIT(struct vut_str, alloc);
 }
 
-struct vut_str vut_str_from_vut_sv(struct vut_sv sv, struct vut_allocator *alloc) {
+struct vut_str vut_str_from_vut_sv(struct vut_sv sv, struct vut_allocator alloc) {
 	struct vut_str ret = vut_str_init(alloc);
 	vut_str_put_sv(&ret, sv);
 	return ret;

--- a/subprojects/vutils/system_allocator.c
+++ b/subprojects/vutils/system_allocator.c
@@ -34,9 +34,9 @@ static const struct vut_allocator_funcs system_alloc_funcs = {
 
 struct vut_allocator sys_allocator = {
 	.base_allocator = NULL,
-	.funcs = system_alloc_funcs,
+	.funcs = &system_alloc_funcs,
 };
 
-struct vut_allocator *vut_get_system_allocator() {
-	return &sys_allocator;
+struct vut_allocator vut_get_system_allocator() {
+	return sys_allocator;
 }

--- a/subprojects/vutils_tests/allocator.c
+++ b/subprojects/vutils_tests/allocator.c
@@ -19,7 +19,7 @@ struct allocator_case {
 };
 
 static struct vut_allocator gen_sys_allocator() {
-	return *vut_get_system_allocator();
+	return vut_get_system_allocator();
 }
 
 static struct vut_allocator gen_arena_allocator() {
@@ -50,7 +50,7 @@ static void test_malloc_simple(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_malloc(&alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
+		size_t *arr = vut_allocator_malloc(alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
 		for (size_t j = 0; j < DEFAULT_ALLOC_SIZE; j++) {
 			arr[j] = j;
 			VUNIT_ASSERT_EQ(ctx, arr[j], j);
@@ -66,7 +66,7 @@ static void test_malloc_zero_size_allocation(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_malloc(&alloc, sizeof(*arr), 0);
+		size_t *arr = vut_allocator_malloc(alloc, sizeof(*arr), 0);
 		VUNIT_ASSERT_EQ(ctx, arr, NULL);
 
 		if (c->destroy_allocator != NULL)
@@ -79,7 +79,7 @@ static void test_calloc_simple(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_calloc(&alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
+		size_t *arr = vut_allocator_calloc(alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
 		for (size_t j = 0; j < DEFAULT_ALLOC_SIZE; j++) {
 			VUNIT_ASSERT_EQ(ctx, arr[j], 0);
 			arr[j] = j;
@@ -96,7 +96,7 @@ static void test_calloc_zero_size_allocation(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_calloc(&alloc, sizeof(*arr), 0);
+		size_t *arr = vut_allocator_calloc(alloc, sizeof(*arr), 0);
 		VUNIT_ASSERT_EQ(ctx, arr, NULL);
 
 		if (c->destroy_allocator != NULL)
@@ -109,11 +109,11 @@ static void test_realloc_simple(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_malloc(&alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
+		size_t *arr = vut_allocator_malloc(alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
 		for (size_t j = 0; j < DEFAULT_ALLOC_SIZE; j++) {
 			arr[j] = j;
 		}
-		arr = vut_allocator_realloc(&alloc, arr, sizeof(*arr), DEFAULT_ALLOC_SIZE * 2);
+		arr = vut_allocator_realloc(alloc, arr, sizeof(*arr), DEFAULT_ALLOC_SIZE * 2);
 		for (size_t j = 0; j < DEFAULT_ALLOC_SIZE; j++) {
 			VUNIT_ASSERT_EQ(ctx, arr[j], j);
 		}
@@ -132,11 +132,11 @@ static void test_realloc_zero_size(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		size_t *arr = vut_allocator_malloc(&alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
+		size_t *arr = vut_allocator_malloc(alloc, sizeof(*arr), DEFAULT_ALLOC_SIZE);
 		for (size_t j = 0; j < DEFAULT_ALLOC_SIZE; j++) {
 			arr[j] = j;
 		}
-		arr = vut_allocator_realloc(&alloc, arr, sizeof(*arr), 0);
+		arr = vut_allocator_realloc(alloc, arr, sizeof(*arr), 0);
 		VUNIT_ASSERT_EQ(ctx, arr, NULL);
 
 		if (c->destroy_allocator != NULL)
@@ -150,7 +150,7 @@ static void test_free_null(struct vunit_test_ctx *ctx) {
 		struct allocator_case *c = &allocator_cases[i];
 		struct vut_allocator alloc = c->gen_allocator();
 
-		vut_allocator_free(&alloc, NULL);
+		vut_allocator_free(alloc, NULL);
 
 		if (c->destroy_allocator != NULL)
 			c->destroy_allocator(alloc);

--- a/subprojects/vutils_tests/futils.c
+++ b/subprojects/vutils_tests/futils.c
@@ -19,7 +19,7 @@ void test_fut_read_all_FILE(struct vunit_test_ctx *ctx) {
 	const char buff[] = "hello world!";
 	fwrite(buff, sizeof(buff), 1, fp);
 
-	struct vut_str msg = vut_fut_read_all_FILE(fp, &ctx->allocator);
+	struct vut_str msg = vut_fut_read_all_FILE(fp, ctx->allocator);
 
 	char *ret = vut_str_move_to_cstr(&msg);
 

--- a/subprojects/vutils_tests/vec_macros.c
+++ b/subprojects/vutils_tests/vec_macros.c
@@ -6,7 +6,7 @@
 struct int_vec_t VUT_VEC_DEF(int);
 
 void test_vec_reserve_exact(struct vunit_test_ctx *ctx) {
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_RESERVE_EXACT(&vec, 5);
 	VUNIT_ASSERT_EQ(ctx, vec.len, 0);
@@ -25,7 +25,7 @@ void test_vec_reserve_exact(struct vunit_test_ctx *ctx) {
 }
 
 void test_vec_reserve(struct vunit_test_ctx *ctx) {
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_RESERVE(&vec, 5);
 	VUNIT_ASSERT_EQ_MSG(ctx, vec.len, 0, "VUT_VEC_RESERVE should not change the length");
@@ -44,7 +44,7 @@ void test_vec_reserve(struct vunit_test_ctx *ctx) {
 }
 
 void test_vec_put(struct vunit_test_ctx *ctx) {
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_RESERVE_EXACT(&vec, 3);
 	VUT_VEC_PUT(&vec, 1);
@@ -69,7 +69,7 @@ void test_vec_put(struct vunit_test_ctx *ctx) {
 }
 
 void test_vec_pop(struct vunit_test_ctx *ctx) {
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_RESERVE_EXACT(&vec, 3);
 
@@ -96,7 +96,7 @@ void test_vec_pop(struct vunit_test_ctx *ctx) {
 
 void test_vec_put_many(struct vunit_test_ctx *ctx) {
 	int source[] = { 9, 8, 7, 6 };
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_PUT_MANY(&vec, source, 4);
 
@@ -114,7 +114,7 @@ void test_vec_put_many(struct vunit_test_ctx *ctx) {
 
 void test_vec_foreach(struct vunit_test_ctx *ctx) {
 	int source[] = { 9, 8, 7, 6 };
-	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, &ctx->allocator);
+	struct int_vec_t vec = VUT_VEC_INIT(struct int_vec_t, ctx->allocator);
 
 	VUT_VEC_PUT_MANY(&vec, source, sizeof(source) / sizeof(source[0]));
 


### PR DESCRIPTION
The struct vut_allocator is just a fancy ponter already. Having it always be passed by pointer requires some extra alocation in some cases.

An example would be if you have a function that returns a struct that has a vut_allocator and a VUT_VEC that uses the same allocator. If the VUT_VEC accepts a struct vut_allocator* it will receive a stack address in a stack if you don't malloc the struct vut_allocator.