### PR TITLE
meson: Set the c std to c17

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('vinum', 'c', meson_version: '>=0.61.2',
   default_options : [
+    'c_std=c17',
     'werror=true',
     'warning_level=2',
     'c_args=-Wformat-security',

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -5,6 +5,8 @@
 
 %option extra-type="struct compiler_ctx *"
 
+%option never-interactive
+
 %x DEFINE_CALL_NAME
 %x HAS_CALL_NAME
 %x CONTENT

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -354,14 +354,14 @@ void resolve_extern_functions(struct eval_ctx *ctx, struct loaded_lib lib) {
 	}
 }
 
-struct loaded_lib *load_libs(struct eval_ctx *ctx, struct str_vec *libraries) {
+struct loaded_lib *load_libs(struct eval_ctx *ctx, struct sv_vec *libraries) {
 	size_t len = libraries->len;
 	if (len == 0)
 		return NULL;
 	struct loaded_lib *loaded_libs =
 		vut_allocator_calloc(ctx->allocator, sizeof(struct loaded_lib), len + 1);
 	for (size_t i = 0; i < len; i++) {
-		loaded_libs[i] = load_lib(VUT_VEC_AT(libraries, i));
+		loaded_libs[i] = load_lib(VUT_VEC_AT(libraries, i), *ctx->allocator);
 		resolve_extern_functions(ctx, loaded_libs[i]);
 	}
 	loaded_libs[len].dl_handle = NULL;
@@ -380,7 +380,7 @@ void unload_libs(struct loaded_lib *loaded_libs, struct vut_allocator *alloc) {
 	vut_allocator_free(alloc, loaded_libs);
 }
 
-struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct str_vec *libraries) {
+struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct sv_vec *libraries) {
 	struct scope base_scope = scope_new(0, -1, ctx->allocator);
 	VUT_VEC_PUT(&ctx->scopes, base_scope);
 

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -44,9 +44,9 @@ struct eval_ctx {
 
 struct eval_ctx eval_ctx_new(struct vut_allocator *allocator);
 
-struct str_vec VUT_VEC_DEF(char *);
+struct sv_vec VUT_VEC_DEF(struct vut_sv);
 
-struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct str_vec *libraries);
+struct vut_str eval(struct eval_ctx *ctx, struct ast *ast, struct sv_vec *libraries);
 
 void eval_dot(const struct eval_ctx *ctx, FILE *stream);
 

--- a/subprojects/vinumc/library_loader.c
+++ b/subprojects/vinumc/library_loader.c
@@ -1,9 +1,14 @@
 #include <assert.h>
 #include <dlfcn.h>
+
 #include <extern_library.h>
 
-struct loaded_lib load_lib(char *name) {
-	void *handle = dlopen(name, RTLD_LAZY);
+#include "library_loader.h"
+
+struct loaded_lib load_lib(struct vut_sv name, struct vut_allocator alloc) {
+	char *name_cstr = vut_sv_to_cstr(name, alloc);
+	void *handle = dlopen(name_cstr, RTLD_LAZY);
+	vut_allocator_free(&alloc, name_cstr);
 
 	// TODO: deal with the error of not being able to open the library
 	assert(handle);

--- a/subprojects/vinumc/library_loader.h
+++ b/subprojects/vinumc/library_loader.h
@@ -1,7 +1,10 @@
 #ifndef __LIBRARY_LOADER_H__
 #define __LIBRARY_LOADER_H__
 
-struct loaded_lib load_lib(char *name);
+#include <vutils/allocator.h>
+#include <vutils/sv.h>
+
+struct loaded_lib load_lib(struct vut_sv name, struct vut_allocator alloc);
 void unload_lib(struct loaded_lib lib);
 
 #endif //__LIBRARY_LOADER_H__

--- a/subprojects/vinumc/libvinumc.c
+++ b/subprojects/vinumc/libvinumc.c
@@ -5,7 +5,7 @@ struct compiler_ctx compiler_ctx_init(struct vut_allocator *alloc) {
 	struct compiler_ctx ctx = {
 		.ast = ast_new(alloc),
 		.eval_ctx = eval_ctx_new(alloc),
-		.libraries = VUT_VEC_INIT(struct str_vec, alloc),
+		.libraries = VUT_VEC_INIT(struct sv_vec, alloc),
 		.dry_flex_text_buffer = vut_str_init(alloc),
 
 		.alloc = alloc,

--- a/subprojects/vinumc/libvinumc.h
+++ b/subprojects/vinumc/libvinumc.h
@@ -10,7 +10,7 @@
 struct compiler_ctx {
 	struct ast ast;
 	struct eval_ctx eval_ctx;
-	struct str_vec libraries;
+	struct sv_vec libraries;
 	// used to handle character escaping inside the regular text blocks
 	// preventing having two consecutive TEXT nodes
 	// that could be just one node

--- a/subprojects/vinumc/tests/library_test.c
+++ b/subprojects/vinumc/tests/library_test.c
@@ -7,7 +7,7 @@ static char *compile_program_with_testlib(const char *prg_cstr, struct vut_alloc
 
 	struct vut_str prg = vut_str_init(alloc);
 	vut_str_put_cstr(&prg, prg_cstr);
-	VUT_VEC_PUT(&comp.libraries, "subprojects/vinumc/tests/libtestlib.so");
+	VUT_VEC_PUT(&comp.libraries, vut_sv_from_cstr("subprojects/vinumc/tests/libtestlib.so"));
 
 	struct vut_str out = compiler_compile(&comp, &prg);
 

--- a/subprojects/vinumc/vinumc.c
+++ b/subprojects/vinumc/vinumc.c
@@ -41,7 +41,7 @@ struct flag {
 	union {
 		bool *boolean;
 		char **str;
-		struct str_vec *str_vec;
+		struct sv_vec *sv_vec;
 	} ref_as;
 };
 
@@ -102,8 +102,7 @@ static void parse_cmdline(const int argc, char **argv, struct ctx *ctx, struct f
 			*f->ref_as.boolean = true;
 			break;
 		case FLAG_MULTI_ARGUMENTS: {
-			char *tmp = strdup(optarg);
-			VUT_VEC_PUT(f->ref_as.str_vec, tmp);
+			VUT_VEC_PUT(f->ref_as.sv_vec, vut_sv_from_cstr(optarg));
 		} break;
 		}
 	}
@@ -188,7 +187,7 @@ int main(int argc, char **argv) {
 			.help_desc = "Set a library to be loaded",
 			.placeholder_name = "libraries",
 			.kind = FLAG_MULTI_ARGUMENTS,
-			.ref_as.str_vec = &ctx.compiler.libraries,
+			.ref_as.sv_vec = &ctx.compiler.libraries,
 		},
 	};
 

--- a/subprojects/vutils/include/vutils/sv.h
+++ b/subprojects/vutils/include/vutils/sv.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+#include "allocator.h"
+
 #define VUT_SV_FMT "%.*s"
 #define VUT_SV_ARG(s) (int)(s).len, (s).base
 
@@ -16,6 +18,8 @@ struct vut_str;
 struct vut_sv vut_sv_from_str(const char *str, size_t len);
 struct vut_sv vut_sv_from_cstr(const char *cstr);
 struct vut_sv vut_sv_from_vut_str(const struct vut_str *str);
+
+char *vut_sv_to_cstr(const struct vut_sv sv, struct vut_allocator alloc);
 
 bool vut_sv_eq(struct vut_sv a, struct vut_sv b);
 

--- a/subprojects/vutils/sv.c
+++ b/subprojects/vutils/sv.c
@@ -19,6 +19,12 @@ struct vut_sv vut_sv_from_vut_str(const struct vut_str *str) {
 	return vut_sv_from_str(str->base, str->len);
 }
 
+char *vut_sv_to_cstr(const struct vut_sv sv, struct vut_allocator alloc) {
+	char *ret = vut_allocator_calloc(&alloc, sizeof(*ret), sv.len + 1);
+	memcpy(ret, sv.base, sizeof(*ret) * sv.len);
+	return ret;
+}
+
 bool vut_sv_eq(struct vut_sv a, struct vut_sv b) {
 	if (a.len != b.len)
 		return false;


### PR DESCRIPTION
We don't specify the cstd that we are writing the code. Let's specify c17, it's c11 with some bug fixes.