### PR TITLE
Remove all memory leaks from vinumc

### DIFF
--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -22,6 +22,12 @@ struct ast ast_new(struct vut_allocator allocator) {
 	return ret;
 }
 
+void ast_free(struct ast *ast) {
+	VUT_VEC_FREE(&ast->nodes);
+
+	*ast = (struct ast){};
+}
+
 ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node) {
 	VUT_VEC_PUT(&ast->nodes, node);
 	return ast->nodes.len - 1;

--- a/subprojects/vinumc/ast.c
+++ b/subprojects/vinumc/ast.c
@@ -3,15 +3,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <vutils/arena_allocator.h>
+
 #include "ast.h"
-
-struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator allocator) {
-	struct ast_node ret = { .type = type,
-				.text = text,
-				.childs = VUT_VEC_INIT(struct ast_node_childs_t, allocator) };
-
-	return ret;
-}
 
 struct ast ast_new(struct vut_allocator allocator) {
 	struct ast ret = {
@@ -19,24 +13,39 @@ struct ast ast_new(struct vut_allocator allocator) {
 		.allocator = allocator,
 	};
 
+	struct vut_arena *arena = vut_allocator_malloc(allocator, sizeof(*arena), 1);
+	*arena = vut_arena_new(allocator, 10 * 1024);
+	ret.child_arena = vut_arena_to_vut_allocator(arena);
+
 	return ret;
 }
 
 void ast_free(struct ast *ast) {
+	vut_arena_free_all(ast->child_arena.base_allocator);
+	vut_allocator_free(ast->allocator, ast->child_arena.base_allocator);
 	VUT_VEC_FREE(&ast->nodes);
 
 	*ast = (struct ast){};
 }
 
-ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node) {
+static ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node) {
 	VUT_VEC_PUT(&ast->nodes, node);
 	return ast->nodes.len - 1;
+}
+
+ast_node_id_t ast_node_new(struct ast *ast, const int type, struct vut_sv text) {
+	struct ast_node node = { .type = type,
+				 .text = text,
+				 .childs =
+					 VUT_VEC_INIT(struct ast_node_childs_t, ast->child_arena) };
+
+	return ast_add_node(ast, node);
 }
 
 ast_node_id_t ast_copy_node(struct ast *ast, ast_node_id_t node_id) {
 	struct ast_node no_childs_copy = VUT_VEC_AT(&ast->nodes, node_id);
 
-	no_childs_copy.childs = VUT_VEC_INIT(struct ast_node_childs_t, ast->allocator);
+	no_childs_copy.childs = VUT_VEC_INIT(struct ast_node_childs_t, ast->child_arena);
 
 	size_t node_copy_id = ast_add_node(ast, no_childs_copy);
 	struct ast_node *node_copy = &VUT_VEC_AT(&ast->nodes, node_copy_id);

--- a/subprojects/vinumc/ast.h
+++ b/subprojects/vinumc/ast.h
@@ -22,22 +22,22 @@ struct ast_node {
 	struct ast_node_childs_t childs;
 };
 
-struct ast_node ast_node_new(const int type, struct vut_sv text, struct vut_allocator allocator);
-#define ast_node_new_nvl(type, allocator) (ast_node_new((type), (struct vut_sv){ 0 }, (allocator)))
-
 struct ast_nodes_t VUT_VEC_DEF(struct ast_node);
 
 struct ast {
 	struct ast_nodes_t nodes;
 
 	struct vut_allocator allocator;
+	struct vut_allocator child_arena;
 };
 
 struct ast ast_new(struct vut_allocator allocator);
 void ast_free(struct ast *ast);
 
+ast_node_id_t ast_node_new(struct ast *ast, const int type, struct vut_sv text);
+#define ast_node_new_nvl(ast, type) (ast_node_new((ast), (type), (struct vut_sv){ 0 }))
+
 const char *token_to_str(enum yytokentype token);
-ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node);
 ast_node_id_t ast_copy_node(struct ast *ast, ast_node_id_t node_id);
 
 ast_node_id_t ast_get_num_child(const struct ast *ast, ast_node_id_t id);

--- a/subprojects/vinumc/ast.h
+++ b/subprojects/vinumc/ast.h
@@ -34,6 +34,7 @@ struct ast {
 };
 
 struct ast ast_new(struct vut_allocator allocator);
+void ast_free(struct ast *ast);
 
 const char *token_to_str(enum yytokentype token);
 ast_node_id_t ast_add_node(struct ast *ast, const struct ast_node node);

--- a/subprojects/vinumc/dry_bison.y
+++ b/subprojects/vinumc/dry_bison.y
@@ -106,7 +106,7 @@ args_child:
 symbol: SYMBOL {
 	// making so our symbols are case insensitive by making the whole string lowercase
 	struct vut_sv text = ast_get_text(&ctx->ast, $1);
-	struct vut_str tmp_str = vut_str_from_vut_sv(text, ctx->alloc);
+	struct vut_str tmp_str = vut_str_from_vut_sv(text, ctx->dry_arena);
 
 	// we need to convert from multi-byte to wide-character string
 	wchar_t *wtext = (wchar_t*)malloc(text.len * sizeof(wchar_t));

--- a/subprojects/vinumc/dry_bison.y
+++ b/subprojects/vinumc/dry_bison.y
@@ -47,8 +47,7 @@ void yyerror(yyscan_t scanner, struct compiler_ctx *ctx, const char *fmt, ...);
 program:
        {
        UNUSED(yynerrs);
-	struct ast_node node = ast_node_new_nvl(PROGRAM, ctx->ast.allocator);
-	$$ = ast_add_node(&ctx->ast, node);
+	$$ = ast_node_new_nvl(&ctx->ast, PROGRAM);
        }
        | program block {
 	ast_add_child(&ctx->ast, $1, $2);
@@ -58,7 +57,7 @@ program:
 
 block:
      '[' symbol ':' args ']'  {
-	ast_node_id_t node = ast_add_node(&ctx->ast, ast_node_new_nvl(ASSIGNMENT, ctx->ast.allocator));
+	ast_node_id_t node = ast_node_new_nvl(&ctx->ast, ASSIGNMENT);
 
 	ast_add_child(&ctx->ast, node, $2);
 	ast_add_child(&ctx->ast, node, $4);
@@ -66,7 +65,7 @@ block:
 	$$ = node;
    }
    | '[' symbol args ']'  {
-	ast_node_id_t node = ast_add_node(&ctx->ast, ast_node_new_nvl(CALL, ctx->ast.allocator));
+	ast_node_id_t node = ast_node_new_nvl(&ctx->ast, CALL);
 
 	ast_add_child(&ctx->ast, node, $2);
 	ast_add_child(&ctx->ast, node, $3);
@@ -74,7 +73,7 @@ block:
 	$$ = node;
    }
    | '[' symbol ']'  {
-	ast_node_id_t node = ast_add_node(&ctx->ast, ast_node_new_nvl(CALL, ctx->ast.allocator));
+	ast_node_id_t node = ast_node_new_nvl(&ctx->ast, CALL);
 
 	ast_add_child(&ctx->ast, node, $2);
 
@@ -84,7 +83,7 @@ block:
 
 args:
 	args_child {
-		ast_node_id_t node = ast_add_node(&ctx->ast, ast_node_new_nvl(ARGS, ctx->ast.allocator));
+		ast_node_id_t node = ast_node_new_nvl(&ctx->ast, ARGS);
 		ast_add_child(&ctx->ast, node, $1);
 
 		$$ = node;
@@ -127,7 +126,7 @@ symbol: SYMBOL {
 	$$ = $1;
       }
       | block {
-	ast_node_id_t node = ast_add_node(&ctx->ast, ast_node_new_nvl(SYMBOL, ctx->ast.allocator));
+	ast_node_id_t node = ast_node_new_nvl(&ctx->ast, SYMBOL);
 	ast_add_child(&ctx->ast, node, $1);
 
 	$$ = node;

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -148,7 +148,7 @@ static int yield_text_node(yyscan_t yyscanner) {
 		extra->ast.allocator
 	);
 	// transfers the string to the ast node
-	extra->dry_flex_text_buffer = vut_str_init(extra->ast.allocator);
+	extra->dry_flex_text_buffer = vut_str_init(extra->dry_arena);
 
 	*lval = ast_add_node(&extra->ast, node);
 	return TEXT;

--- a/subprojects/vinumc/dry_flex.l
+++ b/subprojects/vinumc/dry_flex.l
@@ -41,8 +41,7 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 
 <INITIAL>[ \t\r\n]+ ;
 <INITIAL>[^\[\] \t\r\n]+ {
-	struct ast_node node = ast_node_new(TEXT, vut_sv_from_cstr(yytext), yyextra->ast.allocator);
-	*yylval = ast_add_node(&yyextra->ast, node);
+	*yylval = ast_node_new(&yyextra->ast, TEXT, vut_sv_from_cstr(yytext));
 
 	return TEXT;
 }
@@ -60,8 +59,7 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 <DEFINE_CALL_NAME,HAS_CALL_NAME>[ \t]*: { replace_state(CONTENT, yyscanner); return ':'; }
 <DEFINE_CALL_NAME>[ \t\r\n]+ ;
 <DEFINE_CALL_NAME>[^\[\]: \t\r\n]+ {
-	struct ast_node node = ast_node_new(SYMBOL, vut_sv_from_cstr(yytext), yyextra->ast.allocator);
-	*yylval = ast_add_node(&yyextra->ast, node);
+	*yylval = ast_node_new(&yyextra->ast, SYMBOL, vut_sv_from_cstr(yytext));
 
 	replace_state(HAS_CALL_NAME, yyscanner);
 
@@ -71,16 +69,14 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 <HAS_CALL_NAME>. { replace_state(CONTENT, yyscanner); yyless(0); }
 
 <CONTENT>"$*" {
-	struct ast_node node = ast_node_new_nvl(ARG_REF_ALL_ARGS, yyextra->ast.allocator);
-	*yylval = ast_add_node(&yyextra->ast, node);
+	*yylval = ast_node_new_nvl(&yyextra->ast, ARG_REF_ALL_ARGS);
 
 	return ARG_REF_ALL_ARGS;
 }
 
 <CONTENT>"{#" { yy_push_state(IN_LITERAL, yyscanner); }
 <IN_LITERAL>"#}" {
-	struct ast_node node = ast_node_new(LITERAL, vut_sv_from_str(yytext, yyleng - 2), yyextra->ast.allocator);
-	*yylval = ast_add_node(&yyextra->ast, node);
+	*yylval = ast_node_new(&yyextra->ast, LITERAL, vut_sv_from_str(yytext, yyleng - 2));
 
 	yy_pop_state(yyscanner);
 	return LITERAL;
@@ -91,9 +87,7 @@ BEFORE_TEXT_END ("["|"]"|"$*"|"{#")
 <IN_LITERAL>(.|\n) {
 	// the next token is eof, so we yield the
 	// contents buffered so far
-	struct ast_node node = ast_node_new(LITERAL, vut_sv_from_str(yytext, yyleng),
-	yyextra->ast.allocator);
-	*yylval = ast_add_node(&yyextra->ast, node);
+	*yylval = ast_node_new(&yyextra->ast, LITERAL, vut_sv_from_str(yytext, yyleng));
 	yy_pop_state(yyscanner);
 	return LITERAL;
 }
@@ -142,14 +136,13 @@ static int yield_text_node(yyscan_t yyscanner) {
 	YYSTYPE * lval = yyget_lval(yyscanner);
 	struct compiler_ctx * extra = yyget_extra(yyscanner);
 
-	struct ast_node node = ast_node_new(
+	*lval = ast_node_new(
+		&extra->ast,
 		TEXT,
-		vut_sv_from_vut_str(&extra->dry_flex_text_buffer),
-		extra->ast.allocator
+		vut_sv_from_vut_str(&extra->dry_flex_text_buffer)
 	);
 	// transfers the string to the ast node
 	extra->dry_flex_text_buffer = vut_str_init(extra->dry_arena);
 
-	*lval = ast_add_node(&extra->ast, node);
 	return TEXT;
 }

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -31,6 +31,12 @@ struct eval_ctx eval_ctx_new(struct vut_allocator allocator) {
 	return ret;
 }
 
+void eval_ctx_free(struct eval_ctx *ctx) {
+	VUT_VEC_FREE(&ctx->scopes);
+
+	*ctx = (struct eval_ctx){ 0 };
+}
+
 static struct scope scope_new(ast_node_id_t node, int father, struct vut_allocator allocator) {
 	struct scope new_scope = {
 		.father = father,

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -243,8 +243,7 @@ RESOLVE_FUNC_SIGNATURE(resolve_calls_call) {
 			if (ast_get_num_child(ast, ast_node) <= 1) {
 				// ensure that the call node has an ARGS node
 				// to prevent it from being skipped during evaluation
-				size_t args_node_id =
-					ast_add_node(ast, ast_node_new_nvl(ARGS, ast->allocator));
+				size_t args_node_id = ast_node_new_nvl(ast, ARGS);
 				ast_add_child(ast, ast_node, args_node_id);
 			}
 		}

--- a/subprojects/vinumc/eval.c
+++ b/subprojects/vinumc/eval.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <vutils/arena_allocator.h>
 #include <vutils/str.h>
 #include <vutils/system_allocator.h>
 #include <vutils/vec.h>
@@ -28,32 +29,45 @@ struct eval_ctx eval_ctx_new(struct vut_allocator allocator) {
 		.scopes = VUT_VEC_INIT(struct eval_ctx_scopes_t, allocator),
 	};
 
+	struct vut_arena *arena = vut_allocator_malloc(allocator, sizeof(*arena), 1);
+	*arena = vut_arena_new(allocator, 10 * 1024);
+	ret.scopes_childs_arena = vut_arena_to_vut_allocator(arena);
+
+	arena = vut_allocator_malloc(allocator, sizeof(*arena), 1);
+	*arena = vut_arena_new(allocator, 10 * 1024);
+	ret.scopes_namespace_arena = vut_arena_to_vut_allocator(arena);
+
 	return ret;
 }
 
 void eval_ctx_free(struct eval_ctx *ctx) {
+	vut_arena_free_all(ctx->scopes_namespace_arena.base_allocator);
+	vut_allocator_free(ctx->allocator, ctx->scopes_namespace_arena.base_allocator);
+
+	vut_arena_free_all(ctx->scopes_childs_arena.base_allocator);
+	vut_allocator_free(ctx->allocator, ctx->scopes_childs_arena.base_allocator);
+
 	VUT_VEC_FREE(&ctx->scopes);
 
 	*ctx = (struct eval_ctx){ 0 };
 }
 
-static struct scope scope_new(ast_node_id_t node, int father, struct vut_allocator allocator) {
+static struct scope scope_new(struct eval_ctx *ctx, ast_node_id_t node, int father) {
 	struct scope new_scope = {
 		.father = father,
 		.node = node,
-		.childs = VUT_VEC_INIT(struct scope_childs_t, allocator),
-		.namespace = VUT_VEC_INIT(struct scope_namespace_t, allocator),
+		.childs = VUT_VEC_INIT(struct scope_childs_t, ctx->scopes_childs_arena),
+		.namespace = VUT_VEC_INIT(struct scope_namespace_t, ctx->scopes_namespace_arena),
 	};
 	return new_scope;
 }
 
-static size_t add_scope_child(struct eval_ctx_scopes_t *scope_array, size_t scope_id,
-			      ast_node_id_t node, struct vut_allocator allocator) {
-	size_t new_scope_id = scope_array->len;
-	struct scope new_scope = scope_new(node, scope_id, allocator);
+static size_t add_scope_child(struct eval_ctx *ctx, size_t father, ast_node_id_t node) {
+	size_t new_scope_id = ctx->scopes.len;
+	struct scope new_scope = scope_new(ctx, node, father);
 
-	VUT_VEC_PUT(scope_array, new_scope);
-	struct scope *scope = &scope_array->base[scope_id];
+	VUT_VEC_PUT(&ctx->scopes, new_scope);
+	struct scope *scope = &ctx->scopes.base[father];
 	VUT_VEC_PUT(&scope->childs, new_scope_id);
 
 	return new_scope_id;
@@ -152,8 +166,8 @@ RESOLVE_FUNC_SIGNATURE(resolve_symbols) {
 		resolve_symbols_assignment(cctx, curr_scope_id, ast_node);
 	} else {
 		if (ast_get_type(ast, ast_node) == CALL)
-			curr_scope_id = add_scope_child(&ctx->scopes, curr_scope_id, ast_node,
-							ctx->allocator);
+			curr_scope_id = add_scope_child(ctx, curr_scope_id, ast_node);
+
 		resolve_symbols_descent(cctx, curr_scope_id, ast_node);
 	}
 }
@@ -419,7 +433,7 @@ void unload_libs(struct loaded_lib *loaded_libs, struct vut_allocator alloc) {
 
 struct vut_str eval(struct compiler_ctx *cctx) {
 	struct eval_ctx *ctx = &cctx->eval_ctx;
-	struct scope base_scope = scope_new(0, -1, ctx->allocator);
+	struct scope base_scope = scope_new(ctx, 0, -1);
 	VUT_VEC_PUT(&ctx->scopes, base_scope);
 
 	struct loaded_lib *loaded_libs = load_libs(ctx, &cctx->libraries);

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -39,7 +39,10 @@ struct eval_ctx_scopes_t VUT_VEC_DEF(struct scope);
 
 struct eval_ctx {
 	struct eval_ctx_scopes_t scopes;
+
 	struct vut_allocator allocator;
+	struct vut_allocator scopes_childs_arena;
+	struct vut_allocator scopes_namespace_arena;
 };
 
 struct eval_ctx eval_ctx_new(struct vut_allocator allocator);

--- a/subprojects/vinumc/eval.h
+++ b/subprojects/vinumc/eval.h
@@ -43,6 +43,7 @@ struct eval_ctx {
 };
 
 struct eval_ctx eval_ctx_new(struct vut_allocator allocator);
+void eval_ctx_free(struct eval_ctx *ctx);
 
 struct sv_vec VUT_VEC_DEF(struct vut_sv);
 

--- a/subprojects/vinumc/libvinumc.c
+++ b/subprojects/vinumc/libvinumc.c
@@ -21,6 +21,17 @@ struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc) {
 	return ctx;
 }
 
+void compiler_ctx_free(struct compiler_ctx *ctx) {
+	vut_arena_free_all(ctx->dry_arena.base_allocator);
+	vut_allocator_free(ctx->alloc, ctx->dry_arena.base_allocator);
+
+	VUT_VEC_FREE(&ctx->libraries);
+	eval_ctx_free(&ctx->eval_ctx);
+	ast_free(&ctx->ast);
+
+	*ctx = (struct compiler_ctx){ 0 };
+}
+
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
 void compiler_parse(struct compiler_ctx *ctx, struct vut_str *program) {

--- a/subprojects/vinumc/libvinumc.c
+++ b/subprojects/vinumc/libvinumc.c
@@ -1,5 +1,6 @@
 #include "libvinumc.h"
 #include "dry_flex.h"
+#include <vutils/arena_allocator.h>
 
 struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc) {
 	struct compiler_ctx ctx = {
@@ -10,6 +11,12 @@ struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc) {
 
 		.alloc = alloc,
 	};
+
+	struct vut_arena *arena = vut_allocator_malloc(alloc, sizeof(*arena), 1);
+	*arena = vut_arena_new(alloc, 1024),
+
+	ctx.dry_arena = vut_arena_to_vut_allocator(arena);
+	ctx.dry_flex_text_buffer = vut_str_init(ctx.dry_arena);
 
 	return ctx;
 }

--- a/subprojects/vinumc/libvinumc.h
+++ b/subprojects/vinumc/libvinumc.h
@@ -17,6 +17,7 @@ struct compiler_ctx {
 	// that could be just one node
 	struct vut_str dry_flex_text_buffer;
 
+	struct vut_allocator dry_arena;
 	struct vut_allocator alloc;
 };
 

--- a/subprojects/vinumc/libvinumc.h
+++ b/subprojects/vinumc/libvinumc.h
@@ -22,6 +22,7 @@ struct compiler_ctx {
 };
 
 struct compiler_ctx compiler_ctx_init(struct vut_allocator alloc);
+void compiler_ctx_free(struct compiler_ctx *ctx);
 
 void compiler_parse(struct compiler_ctx *ctx, struct vut_str *program);
 struct vut_str compiler_eval(struct compiler_ctx *ctx);

--- a/subprojects/vinumc/vinumc.c
+++ b/subprojects/vinumc/vinumc.c
@@ -26,6 +26,12 @@ struct ctx ctx_new(struct vut_allocator allocator) {
 	return ret;
 }
 
+void ctx_free(struct ctx *ctx) {
+	compiler_ctx_free(&ctx->compiler);
+
+	*ctx = (struct ctx){ 0 };
+}
+
 enum flag_kind {
 	FLAG_BOOLEAN,
 	FLAG_ARGUMENT,
@@ -222,4 +228,5 @@ int main(int argc, char **argv) {
 exit:
 	free_flags(vinumc_flags, ARRAY_SIZE(vinumc_flags));
 	free(ctx.input_path);
+	ctx_free(&ctx);
 }


### PR DESCRIPTION
To test this I configured the meson build folder with:

```bash
meson configure build/ -Db_sanitize=address
```

and ran the current tests. There is still one testing failing with this configuration, but it's the vutils allocator tests and it's only because of how the test are done.