### PR TITLE
vinumc/meson: Remove lib prefix from libvinumc target name

### DIFF
--- a/subprojects/vinumc/meson.build
+++ b/subprojects/vinumc/meson.build
@@ -64,7 +64,7 @@ install_subdir(
 )
 
 libvinumc = library(
-  'libvinumc',
+  'vinumc',
   sources: [
       'ast.c',
       'eval.c',


### PR DESCRIPTION
Meson already prepends the 'lib' prefix to library targets. Currently, on UNIX systems, the final library name is 'liblibvinumc'.