### PR TITLE
vutils/system_allocator: Always return NULL on zero-size realloc

### DIFF
--- a/subprojects/vutils/system_allocator.c
+++ b/subprojects/vutils/system_allocator.c
@@ -17,6 +17,10 @@ static void *sys_calloc(void *_, size_t bytes, size_t times) {
 
 static void *sys_realloc(void *_, void *ptr, size_t bytes, size_t times) {
 	(void)_;
+	if (bytes * times == 0) {
+		free(ptr);
+		return NULL;
+	}
 	return realloc(ptr, bytes * times);
 }
 


### PR DESCRIPTION
`sys_malloc` and `sys_calloc` already short-circuit to NULL when `bytes * times == 0`, but `sys_realloc` was forwarding straight to libc `realloc(ptr, 0)`, whose behavior is implementation-defined (and undefined as of C23). On macOS that returns a valid 1-byte allocation, so the existing zero-size realloc test asserted NULL and failed.

Mirror the malloc/calloc guard in `sys_realloc`, also freeing the old buffer to avoid leaking it when the caller shrinks to zero. The arena backend already returns NULL in this case, so vut_allocator_realloc is now consistent across both backends and all platforms.