### PR TITLE
vinumc: Add a flag to show the compiler version

### DIFF
--- a/subprojects/vinumc/config.h.in
+++ b/subprojects/vinumc/config.h.in
@@ -1,0 +1,6 @@
+#ifndef __VINUMC_CONFIG_H__
+#define __VINUMC_CONFIG_H__
+
+#define VINUMC_VERSION @vinumc_version@
+
+#endif // __VINUMC_CONFIG_H__

--- a/subprojects/vinumc/meson.build
+++ b/subprojects/vinumc/meson.build
@@ -127,4 +127,11 @@ if get_option('build_vin2dot')
   )
 endif
 
+conf_data = configuration_data()
+conf_data.set_quoted('vinumc_version', meson.project_version())
+
+configure_file(input : 'config.h.in',
+  output : 'config.h',
+  configuration : conf_data)
+
 subdir('tests')

--- a/subprojects/vinumc/tests/help_flag_test.c
+++ b/subprojects/vinumc/tests/help_flag_test.c
@@ -11,8 +11,8 @@ void test_output_flag(struct vunit_test_ctx *ctx) {
 			    &out, "-h", NULL);
 
 	const char *help_output =
-		"usage: vinumc [-o | --output <output_path>] [-h | --help] [-w | --with "
-		"<libraries>] [<file-input>]\n"
+		"usage: vinumc [-o | --output <output_path>] [-h | --help] [-w | "
+		"--with <libraries>] [-v | --version] [<file-input>]\n"
 		"\n"
 		"Options:\n"
 		"  -o, --output\n"
@@ -22,7 +22,10 @@ void test_output_flag(struct vunit_test_ctx *ctx) {
 		"	Show help\n"
 		"\n"
 		"  -w, --with (can be specified multiple times)\n"
-		"	Set a library to be loaded\n";
+		"	Set a library to be loaded\n"
+		"\n"
+		"  -v, --version\n"
+		"	Show the current vinumc version\n";
 
 	VUNIT_ASSERT_STREQ(ctx, out, help_output);
 

--- a/subprojects/vinumc/vinumc.c
+++ b/subprojects/vinumc/vinumc.c
@@ -13,6 +13,7 @@
 #include <vutils/system_allocator.h>
 #include <vutils/vec.h>
 
+#include "config.h"
 #include "vinumc.h"
 
 #define ARRAY_SIZE(arr) (sizeof((arr)) / sizeof(*(arr)))
@@ -195,12 +196,24 @@ int main(int argc, char **argv) {
 			.kind = FLAG_MULTI_ARGUMENTS,
 			.ref_as.sv_vec = &ctx.compiler.libraries,
 		},
+		{
+			.name = "version",
+			.short_name = 'v',
+			.help_desc = "Show the current vinumc version",
+			.kind = FLAG_BOOLEAN,
+			.ref_as.boolean = &ctx.show_version,
+		},
 	};
 
 	parse_cmdline(argc, argv, &ctx, vinumc_flags, ARRAY_SIZE(vinumc_flags));
 
 	if (ctx.show_help) {
 		print_help("vinumc", vinumc_flags, ARRAY_SIZE(vinumc_flags));
+		goto exit;
+	}
+
+	if (ctx.show_version) {
+		printf("v" VINUMC_VERSION "\n");
 		goto exit;
 	}
 

--- a/subprojects/vinumc/vinumc.h
+++ b/subprojects/vinumc/vinumc.h
@@ -12,6 +12,7 @@ struct ctx {
 	char *input_path;
 	char *output_path;
 	bool show_help;
+	bool show_version;
 
 	struct compiler_ctx compiler;
 


### PR DESCRIPTION
We need a way to show version of the compiler being used. Use Meson's configuration_data() function for that.